### PR TITLE
GCNV-15 integration of cnv app with dias batch

### DIFF
--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -50,6 +50,7 @@ def find_files(project_name, app_dir, pattern="."):
 def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
     print(app_name)
     app_version = dxpy.describe(app_name)['version']
+    print(app_version)
 
     app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
     date = get_date()

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -60,10 +60,10 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
         None: folder created in function dx_make_workflow_dir
     """
     # remove any forward dash in ss_workflow
-    ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
+    #ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
 
-    app_output_dir_pattern = "{ss_workflow_out_dir}/{app_name}_v{version}-{assay}-{date}-{index}/"
+    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -81,7 +81,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    app_output_dir_pattern = "{ss_workflow_out_dir}/{app_name}-{assay}-{date}-{index}/"
+    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -48,8 +48,7 @@ def find_files(project_name, app_dir, pattern="."):
 
 
 def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
-    print(app_name)
-    app_version = dxpy.describe(app_name)['version']
+    app_version = str(dxpy.describe(app_name)['version'])
     print(app_version)
 
     app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -108,8 +108,6 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     )
 
     app_output_dir = make_app_out_dir(assay_config.cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
-    # app_out_dir = "".join([ss_workflow_out_dir, app_name])
-    # dx_make_workflow_dir(app_out_dir)
 
     # Find bam and bai files from sentieon folder
     bambi_files = []

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -57,7 +57,7 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
         assay_id (str): assay ID with the version
 
     Returns:
-        _type_: _description_
+        None: folder created in function dx_make_workflow_dir
     """
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
 
@@ -74,9 +74,7 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
             assay=assay_id, date=date, index=i
         )
 
-        print(app_output_dir)
-
-        if dx_make_workflow_dir(app_output_dir):
+        if (app_output_dir):
             print("Using\t\t%s" % app_output_dir)
             return app_output_dir
         else:

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -90,7 +90,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     i = 1
     while i < 100:  # < 100 runs = sanity check
         app_output_dir = app_output_dir_pattern.format(
-            workflow_dir=app_name, assay=assay_id, date=date, index=i
+            app_name=app_name, assay=assay_id, date=date, index=i
         )
 
         if dx_make_workflow_dir(app_output_dir):

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -59,9 +59,11 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
     Returns:
         None: folder created in function dx_make_workflow_dir
     """
+    # remove any forward dash in ss_workflow
+    ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
 
-    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
+    app_output_dir_pattern = "{ss_workflow_out_dir}/{app_name}_v{version}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists
@@ -102,8 +104,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     # Find project to create jobs and outdirs in
     project_name = get_dx_cwd_project_name()
 
-    # remove any forward dash in ss_workflow
-    ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
+
 
     # Make sure path provided is an actual ss workflow output folder
     assert ss_workflow_out_dir.startswith("/"), (
@@ -120,6 +121,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     app_name = get_object_attribute_from_object_id_or_path(
         assay_config.cnvcall_app_id, "Name"
     )
+
 
     app_output_dir = make_app_output_dir(assay_config.cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -104,8 +104,6 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     # Find project to create jobs and outdirs in
     project_name = get_dx_cwd_project_name()
 
-
-
     # Make sure path provided is an actual ss workflow output folder
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -150,7 +150,6 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         file_ids,
         project_name, app_output_dir
     )
-    print(command)
 
     if dry_run is True:
         print("Final cmd ran: {}".format(command))

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -60,10 +60,10 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
         None: folder created in function dx_make_workflow_dir
     """
     # remove any forward dash in ss_workflow
-    #ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
+    ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
 
-    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
+    app_output_dir_pattern = "{ss_workflow_out_dir}/{app_name}_v{version}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -81,7 +81,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    app_output_dir_pattern = "{ss_workflow_out_dir}-{app_name}-{assay}-{date}-{index}/"
+    app_output_dir_pattern = "{ss_workflow_out_dir}/{app_name}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -128,8 +128,10 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
             for line in fh:  # line can be a sample name or sample tab panel name
                 sample_names.append(line.strip().split("\t")[0])
 
+    # Get the first part of sample_names
+    sample_names = [x.split('-')[0] for x in sample_names]
     # Remove bam/bai files of QC faild samples
-    sample_bambis = [x for x in bambi_files if x.split('_')[0] not in sample_names]
+    sample_bambis = [x for x in bambi_files if x.split('-')[0] not in sample_names]
 
     # Find the file-IDs of the passed bam/bai samples
     file_ids = ""

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -47,8 +47,8 @@ def find_files(project_name, app_dir, pattern="."):
     return search_result
 
 
-def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
-    app_version = str(dxpy.describe(app_name)['version'])
+def make_app_out_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id):
+    app_version = str(dxpy.describe(cnvcall_app_id)['version'])
     print(app_version)
 
     app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -81,8 +81,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    # app_out_dir = "".join([ss_workflow_out_dir, app_name])
-    app_output_dir_pattern = "{app_name}-{assay}-{date}-{index}/"
+    app_output_dir_pattern = "{ss_workflow_out_dir}-{app_name}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists
@@ -90,6 +89,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     i = 1
     while i < 100:  # < 100 runs = sanity check
         app_output_dir = app_output_dir_pattern.format(
+            ss_workflow_out_dir=ss_workflow_out_dir,
             app_name=app_name, assay=assay_id, date=date, index=i
         )
 
@@ -101,6 +101,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
 
         i += 1
 
+    # app_out_dir = "".join([ss_workflow_out_dir, app_name])
     # dx_make_workflow_dir(app_out_dir)
 
     # Find bam and bai files from sentieon folder
@@ -143,7 +144,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcalling_fixed_inputs["interval_list"],
         assay_config.cnvcalling_fixed_inputs["annotation_tsv"],
         file_ids,
-        project_name, app_out_dir
+        project_name, app_output_dir
     )
 
     if dry_run is True:
@@ -151,4 +152,4 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     else:
         subprocess.call(command, shell=True)
 
-    return app_out_dir
+    return app_output_dir

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -48,6 +48,7 @@ def find_files(project_name, app_dir, pattern="."):
 
 
 def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
+    print(app_name)
     app_version = dxpy.describe(app_name)['version']
 
     app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -9,7 +9,8 @@ from general_functions import (
     get_object_attribute_from_object_id_or_path,
     dx_make_workflow_dir,
     find_app_dir,
-    get_stage_input_file_list
+    get_stage_input_file_list,
+    get_date
 )
 
 
@@ -80,8 +81,27 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    app_out_dir = "".join([ss_workflow_out_dir, app_name])
-    dx_make_workflow_dir(app_out_dir)
+    # app_out_dir = "".join([ss_workflow_out_dir, app_name])
+    app_output_dir_pattern = "{app_name}-{assay}-{date}-{index}/"
+    date = get_date()
+
+    # when creating the new folder, check if the folder already exists
+    # increment index until it works or reaches 100
+    i = 1
+    while i < 100:  # < 100 runs = sanity check
+        app_output_dir = app_output_dir_pattern.format(
+            workflow_dir=app_name, assay=assay_id, date=date, index=i
+        )
+
+        if dx_make_workflow_dir(app_output_dir):
+            print("Using\t\t%s" % app_output_dir)
+            return app_output_dir
+        else:
+            print("Skipping\t%s" % app_output_dir)
+
+        i += 1
+
+    # dx_make_workflow_dir(app_out_dir)
 
     # Find bam and bai files from sentieon folder
     bambi_files = []

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -47,7 +47,18 @@ def find_files(project_name, app_dir, pattern="."):
     return search_result
 
 
-def make_app_out_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id):
+def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id):
+    """Creates directory for single app with version, date and attempt
+
+    Args:
+        cnvcall_app_id (str): CNV app ID
+        ss_workflow_out_dir (str): single workflow string
+        app_name (str): App name
+        assay_id (str): assay ID with the version
+
+    Returns:
+        _type_: _description_
+    """
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
 
     app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
@@ -62,6 +73,8 @@ def make_app_out_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id):
             app_name=app_name,version=app_version,
             assay=assay_id, date=date, index=i
         )
+
+        print(app_output_dir)
 
         if dx_make_workflow_dir(app_output_dir):
             print("Using\t\t%s" % app_output_dir)
@@ -107,7 +120,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    app_output_dir = make_app_out_dir(assay_config.cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
+    app_output_dir = make_app_output_dir(assay_config.cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
 
     # Find bam and bai files from sentieon folder
     bambi_files = []

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -47,6 +47,29 @@ def find_files(project_name, app_dir, pattern="."):
     return search_result
 
 
+def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
+    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}-{assay}-{date}-{index}/"
+    date = get_date()
+
+    # when creating the new folder, check if the folder already exists
+    # increment index until it works or reaches 100
+    i = 1
+    while i < 100:  # < 100 runs = sanity check
+        app_output_dir = app_output_dir_pattern.format(
+            ss_workflow_out_dir=ss_workflow_out_dir,
+            app_name=app_name, assay=assay_id, date=date, index=i
+        )
+
+        if dx_make_workflow_dir(app_output_dir):
+            print("Using\t\t%s" % app_output_dir)
+            return app_output_dir
+        else:
+            print("Skipping\t%s" % app_output_dir)
+
+        i += 1
+
+    return None
+
 # Run-level CNV calling of samples that passed QC
 
 
@@ -81,26 +104,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}-{assay}-{date}-{index}/"
-    date = get_date()
-
-    # when creating the new folder, check if the folder already exists
-    # increment index until it works or reaches 100
-    i = 1
-    while i < 100:  # < 100 runs = sanity check
-        app_output_dir = app_output_dir_pattern.format(
-            ss_workflow_out_dir=ss_workflow_out_dir,
-            app_name=app_name, assay=assay_id, date=date, index=i
-        )
-
-        if dx_make_workflow_dir(app_output_dir):
-            print("Using\t\t%s" % app_output_dir)
-            return app_output_dir
-        else:
-            print("Skipping\t%s" % app_output_dir)
-
-        i += 1
-
+    app_output_dir = make_app_out_dir(ss_workflow_out_dir, app_name, assay_id)
     # app_out_dir = "".join([ss_workflow_out_dir, app_name])
     # dx_make_workflow_dir(app_out_dir)
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -146,6 +146,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         file_ids,
         project_name, app_output_dir
     )
+    print(command)
 
     if dry_run is True:
         print("Final cmd ran: {}".format(command))

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -49,7 +49,6 @@ def find_files(project_name, app_dir, pattern="."):
 
 def make_app_out_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id):
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
-    print(app_version)
 
     app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
     date = get_date()
@@ -108,7 +107,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         assay_config.cnvcall_app_id, "Name"
     )
 
-    app_output_dir = make_app_out_dir(ss_workflow_out_dir, app_name, assay_id)
+    app_output_dir = make_app_out_dir(assay_config.cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
     # app_out_dir = "".join([ss_workflow_out_dir, app_name])
     # dx_make_workflow_dir(app_out_dir)
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -48,7 +48,9 @@ def find_files(project_name, app_dir, pattern="."):
 
 
 def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
-    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}-{assay}-{date}-{index}/"
+    app_version = dxpy.describe(app_name)['version']
+
+    app_output_dir_pattern = "{ss_workflow_out_dir}{app_name}_v{version}-{assay}-{date}-{index}/"
     date = get_date()
 
     # when creating the new folder, check if the folder already exists
@@ -57,7 +59,8 @@ def make_app_out_dir(ss_workflow_out_dir, app_name,assay_id):
     while i < 100:  # < 100 runs = sanity check
         app_output_dir = app_output_dir_pattern.format(
             ss_workflow_out_dir=ss_workflow_out_dir,
-            app_name=app_name, assay=assay_id, date=date, index=i
+            app_name=app_name,version=app_version,
+            assay=assay_id, date=date, index=i
         )
 
         if dx_make_workflow_dir(app_output_dir):

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -102,6 +102,9 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
     # Find project to create jobs and outdirs in
     project_name = get_dx_cwd_project_name()
 
+    # remove any forward dash in ss_workflow
+    ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
+
     # Make sure path provided is an actual ss workflow output folder
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -76,7 +76,7 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
             assay=assay_id, date=date, index=i
         )
 
-        if (app_output_dir):
+        if dx_make_workflow_dir(app_output_dir):
             print("Using\t\t%s" % app_output_dir)
             return app_output_dir
         else:


### PR DESCRIPTION
Have attempt folder outputs for cnv calling output as: `appname_appversion-assayname_assayversion-date-attempt`
- before: https://platform.dnanexus.com/projects/GFGYfjj4PygF2VvB4gvgyxQQ/data/output/dias_single_v1.3.0-CEN_v1.0.1-220113-1/eggd_GATKgCNV_call
- after: https://platform.dnanexus.com/projects/GFGYfjj4PygF2VvB4gvgyxQQ/data/output/dias_single_v1.3.0-CEN_v1.0.1-220113-1/eggd_GATKgCNV_call_v1.0.0-CEN_v1.1.5-220822-1

Allow input of first sampleID from samplename as excluded list rather than whole app

More testings: https://cuhbioinformatics.atlassian.net/wiki/spaces/C/pages/2738814981/CEN+Dias+batch+placeholder+title

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/80)
<!-- Reviewable:end -->
