### PR TITLE
GCNV-32 dias batch for cnv reports & small enhancement for cnvcalling

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,3 +22,5 @@ Run the Dias pipeline stored in DNAnexus
   - Generate batch files for CNVcalling
 - reports.py
   - Generate batch files for reports and reanalysis
+- cnvreports.py
+  - Generate batch files for CNV reports and CNV reanalysis

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -7,47 +7,10 @@ import dxpy
 from general_functions import (
     get_dx_cwd_project_name,
     get_object_attribute_from_object_id_or_path,
-    dx_make_workflow_dir,
     find_app_dir,
-    get_stage_input_file_list,
-    get_date,
-    make_app_output_dir
+    make_app_output_dir,
+    find_files
 )
-
-
-def find_files(project_name, app_dir, pattern="."):
-    """Searches for files ending in provided pattern (bam/bai) in a
-    given path (single).
-
-    Args:
-        app_dir (str): single path including directory to output app.
-        pattern (str): searchs for files ending in given pattern.
-        Defaults to ".".
-        project_name (str): The project name on DNAnexus
-
-    Returns:
-        search_result: list containing files ending in given pattern
-        of every sample processed in single.
-    """
-    projectID  = list(dxpy.bindings.search.find_projects(name=project_name))[0]['id']
-    # the pattern is usually "-E 'pattern'" and we dont want the -E part
-    pattern = pattern.split('-E ')[1].replace("'", "")
-    search_result = []
-
-    try:
-        for file in dxpy.bindings.search.find_data_objects(
-            project=projectID, folder=app_dir,classname="file",
-            name=pattern, name_mode="regexp", describe=True
-            ):
-            search_result.append(file["describe"]["name"])
-    except ValueError:
-        print('Could not files {} in {}'.format(
-              pattern,app_dir
-            ))
-
-    return search_result
-
-
 
 # Run-level CNV calling of samples that passed QC
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -10,7 +10,8 @@ from general_functions import (
     dx_make_workflow_dir,
     find_app_dir,
     get_stage_input_file_list,
-    get_date
+    get_date,
+    make_app_output_dir
 )
 
 
@@ -47,44 +48,6 @@ def find_files(project_name, app_dir, pattern="."):
     return search_result
 
 
-def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id):
-    """Creates directory for single app with version, date and attempt
-
-    Args:
-        cnvcall_app_id (str): CNV app ID
-        ss_workflow_out_dir (str): single workflow string
-        app_name (str): App name
-        assay_id (str): assay ID with the version
-
-    Returns:
-        None: folder created in function dx_make_workflow_dir
-    """
-    # remove trailing forward dash in ss_workflow
-    ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
-    app_version = str(dxpy.describe(cnvcall_app_id)['version'])
-
-    app_output_dir_pattern = "{ss_workflow_out_dir}/{app_name}_v{version}-{assay}-{date}-{index}/"
-    date = get_date()
-
-    # when creating the new folder, check if the folder already exists
-    # increment index until it works or reaches 100
-    i = 1
-    while i < 100:  # < 100 runs = sanity check
-        app_output_dir = app_output_dir_pattern.format(
-            ss_workflow_out_dir=ss_workflow_out_dir,
-            app_name=app_name,version=app_version,
-            assay=assay_id, date=date, index=i
-        )
-
-        if dx_make_workflow_dir(app_output_dir):
-            print("Using\t\t%s" % app_output_dir)
-            return app_output_dir
-        else:
-            print("Skipping\t%s" % app_output_dir)
-
-        i += 1
-
-    return None
 
 # Run-level CNV calling of samples that passed QC
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -59,7 +59,7 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
     Returns:
         None: folder created in function dx_make_workflow_dir
     """
-    # remove any forward dash in ss_workflow
+    # remove trailing forward dash in ss_workflow
     ss_workflow_out_dir = ss_workflow_out_dir.rstrip('/')
     app_version = str(dxpy.describe(cnvcall_app_id)['version'])
 
@@ -89,14 +89,14 @@ def make_app_output_dir(cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
 # Run-level CNV calling of samples that passed QC
 
 
-def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample_list):
+def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, excluded_sample_list):
     """Sets off the CNV calling app.
 
     Args:
         ss_workflow_out_dir (str): path to single output
         dry_run (str): optional boolean whether this is a dry/test run
         assay_config (variable): assay config file containing all variables
-        sample_list (file): optional file containg list of samples to exclude
+        excluded_sample_list (file): optional file containg list of samples to exclude
 
     Returns:
         app_out_dir: path to where the CNV calling output will be
@@ -131,12 +131,12 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, sample
         bambi_files.extend(find_files(project_name, folder_path, ext))
 
     # Read in list of samples that did NOT PASS QC
-    if sample_list is None:
+    if excluded_sample_list is None:
         sample_names = []
     else:
         sample_names = []
         # parse sample exclusion file
-        with open(sample_list) as fh:
+        with open(excluded_sample_list) as fh:
             for line in fh:  # line can be a sample name or sample tab panel name
                 sample_names.append(line.strip().split("\t")[0])
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -153,6 +153,7 @@ def run_cnvreports(
     """
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
+        
     assert ss_workflow_out_dir.endswith("/"), (
         "Input directory must be full path (ends with /)")
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -106,7 +106,7 @@ def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_lis
     CNV reports script.
 
     Args:
-        input_dir: single output directory e.g /output/dias_single
+        input_dir: single output directory e.g /output/dias_single/cnvapp
         dry_run: optional arg command from cmd line if its a dry run
         assay_config: contains all the dynamic DNAnexus IDs
         assay_id: optional arg command from cmd line for what assay this is
@@ -145,7 +145,7 @@ def run_cnvreports(
     values from the reports directory and then runs the command.
 
     Args:
-        ss_workflow_out_dir: single output directory e.g /output/dias_single
+        ss_workflow_out_dir: single output directory e.g /output/dias_single/cnvapp
         dry_run: optional arg command from cmd line if its a dry run
         assay_config: contains all the dynamic DNAnexus IDs
         assay_id: optional arg command from cmd line for what assay this is
@@ -153,6 +153,20 @@ def run_cnvreports(
     """
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
+
+    # the directory provided on the path is full, up to the cnv calling app,
+    # lets split the directory up to dias_single and keep the cnvcalling
+    # app in another variable object
+    cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
+    # need to ensure that the cnv calling app dir is in the directory
+    # given on the cmd line
+    if 'GATKgCNV_call' in cnv_calling_dir:
+        print("yay")
+    else:
+        ("Directory path requires cnv calling app directory")
+    # reset the ss_workflow_out_dir to not contain the cnv calling path
+    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
+
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir
     )

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -190,10 +190,10 @@ def run_cnvreports(
                 )
             )
             new_headers.append(
-                "{}.panel".format(assay_config.cnv_generate_workbook_stage_id)
+                "{}.panel".format(assay_config.cnv_generate_bed_vep_stage_id)
             )
             new_headers.append(
-                "{}.panel".format(assay_config.cnv_generate_workbook_stage_id)
+                "{}.panel".format(assay_config.cnv_generate_bed_excluded_stage_id)
             )
             headers.append(tuple(new_headers))
 
@@ -240,7 +240,7 @@ def run_cnvreports(
 
         # get the headers and values from the staging inputs
         rpt_headers, rpt_values = prepare_batch_writing(
-            staging_dict, "reports", assay_config, assay_config.cnv_rpt_dynamic_files
+            staging_dict, "cnvreports", assay_config, assay_config.cnv_rpt_dynamic_files
         )
 
         # manually add the headers for reanalysis vcf2xls/generate_bed

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -40,9 +40,8 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
     # rpt_out_dir should always be /output/dias_single/dias_reports but in case
     # someone adds a "/" at the end, which i do sometimes
     name_file = [
-        ele for ele in rpt_out_dir.split('/') if ele.startswith("dias_reports")
+        ele for ele in rpt_out_dir.split('/') if ele.startswith("dias_cnvreports")
     ]
-    print(name_file)
     # there should only be one ele in name_file
     job_report = "{}.txt".format(name_file[0])
 
@@ -293,9 +292,7 @@ def run_cnvreports(
                 values.append(line)
             else:
                 job_dict["missing_from_manifest"].append(sample_id)
-        print(rpt_workflow_out_dir)
-        print(all_samples)
-        print(job_dict)
+                
         report_file = create_job_reports(
             rpt_workflow_out_dir, all_samples, job_dict
         )
@@ -306,7 +303,7 @@ def run_cnvreports(
 
     args = ""
     args += "-i{}.flank={} ".format(
-        assay_config.cnv_generate_vep_stage_id, assay_config.xlsx_flanks
+        assay_config.cnv_generate_bed_vep_stage_id, assay_config.xlsx_flanks
     )
 
     args += "-i{}.config_file={} ".format(

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -236,7 +236,7 @@ def run_cnvreports(
         sample2stage_input_dict[sample] = stage_input_dict
 
     # get the inputs for the given app-pattern
-    staging_dict = get_stage_inputs(
+    staging_dict = get_stage_inputs_inc_cnv_dir(
         ss_workflow_out_dir, sample2stage_input_dict, cnv_calling_dir
     )
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -16,7 +16,8 @@ from general_functions import (
     parse_genepanels,
     get_sample_ids_from_sample_sheet,
     gather_sample_sheet,
-    get_stage_inputs_inc_cnv_dir
+    get_stage_inputs_inc_cnv_dir,
+    get_stage_inputs
 )
 
 def create_job_reports(rpt_out_dir, all_samples, job_dict):

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -42,7 +42,7 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
     name_file = [
         ele for ele in rpt_out_dir.split('/') if ele.startswith("dias_reports")
     ]
-
+    print(name_file)
     # there should only be one ele in name_file
     job_report = "{}.txt".format(name_file[0])
 
@@ -293,7 +293,9 @@ def run_cnvreports(
                 values.append(line)
             else:
                 job_dict["missing_from_manifest"].append(sample_id)
-
+        print(rpt_workflow_out_dir)
+        print(all_samples)
+        print(job_dict)
         report_file = create_job_reports(
             rpt_workflow_out_dir, all_samples, job_dict
         )

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -102,6 +102,18 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
 
 
 def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
+    """Reads in the reanalysis file given on the command line and runs the
+    CNV reports script.
+
+    Args:
+        input_dir: single output directory e.g /output/dias_single
+        dry_run: optional arg command from cmd line if its a dry run
+        assay_config: contains all the dynamic DNAnexus IDs
+        assay_id: optional arg command from cmd line for what assay this is
+        reanalysis_list: reanalysis file provided on the cmd line
+    """
+
+
     reanalysis_dict = {}
 
     # parse reanalysis file
@@ -129,6 +141,16 @@ def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_lis
 def run_cnvreports(
     ss_workflow_out_dir, dry_run, assay_config, assay_id, reanalysis_dict=None
 ):
+    """Generates batch script with headers from the reports workflow and
+    values from the reports directory and then runs the command.
+
+    Args:
+        ss_workflow_out_dir: single output directory e.g /output/dias_single
+        dry_run: optional arg command from cmd line if its a dry run
+        assay_config: contains all the dynamic DNAnexus IDs
+        assay_id: optional arg command from cmd line for what assay this is
+        reanalysis_dict: reanalysis file IF provided on the cmd line
+    """
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
     rpt_workflow_out_dir = make_workflow_out_dir(

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -154,21 +154,27 @@ def run_cnvreports(
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
 
-    assert ss_workflow_out_dir.endswith("/"), (
-        "Input directory must be full path (ends with /)")
+    # sometimes the backlash maybe provided and we don't want that
+    if ss_workflow_out_dir.endswith("/"):
+        ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
 
     # the directory provided on the path is full, up to the cnv calling app,
     # lets split the directory up to dias_single and keep the cnvcalling
     # app in another variable object
-    #cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
+
+    #get the cnv calling dir name
+    cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
     # need to ensure that the cnv calling app dir is in the directory
     # given on the cmd line
-    # if 'GATKgCNV_call' in cnv_calling_dir:
-    #     print("yay")
-    #else:
-    #    ("Directory path requires cnv calling app directory")
+    if 'GATKgCNV_call' not in cnv_calling_dir:
+        raise AssertionError("Directory path requires cnv calling app directory")
+
     # reset the ss_workflow_out_dir to not contain the cnv calling path
-    #ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
+    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
+
+    print(cnv_calling_dir)
+    print(ss_workflow_out_dir)
+
 
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -154,23 +154,23 @@ def run_cnvreports(
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
 
-    # # sometimes the backlash maybe provided and we don't want that
-    # if ss_workflow_out_dir.endswith("/"):
-    #     ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
+    # sometimes the backlash maybe provided and we don't want that
+    if ss_workflow_out_dir.endswith("/"):
+        ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
 
-    # # the directory provided on the path is full, up to the cnv calling app,
-    # # lets split the directory up to dias_single and keep the cnvcalling
-    # # app in another variable object
+    # the directory provided on the path is full, up to the cnv calling app,
+    # lets split the directory up to dias_single and keep the cnvcalling
+    # app in another variable object
 
-    # #get the cnv calling dir name
-    # cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
-    # # need to ensure that the cnv calling app dir is in the directory
-    # # given on the cmd line
-    # if 'GATKgCNV_call' not in cnv_calling_dir:
-    #     raise AssertionError("Directory path requires cnv calling app directory")
+    # get the cnv calling dir name
+    cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
+    # need to ensure that the cnv calling app dir is in the directory
+    # given on the cmd line
+    if 'GATKgCNV_call' not in cnv_calling_dir:
+        raise AssertionError("Directory path requires cnv calling app directory")
 
-    # # reset the ss_workflow_out_dir to not contain the cnv calling path
-    # ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0] + "/"
+    # reset the ss_workflow_out_dir to not contain the cnv calling path
+    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0] + "/"
 
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -99,7 +99,7 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
 # reanalysis
 
 
-def run_reanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
+def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
     reanalysis_dict = {}
 
     # parse reanalysis file
@@ -118,13 +118,13 @@ def run_reanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
                 # get a dict of sample2panels
                 reanalysis_dict.setdefault(sample, set()).add(panel)
 
-    run_reports(
+    run_cnvreports(
         input_dir, dry_run, assay_config, assay_id,
         reanalysis_dict=reanalysis_dict
     )
 
 
-def run_reports(
+def run_cnvreports(
     ss_workflow_out_dir, dry_run, assay_config, assay_id, reanalysis_dict=None
 ):
     assert ss_workflow_out_dir.startswith("/"), (

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -170,11 +170,7 @@ def run_cnvreports(
         raise AssertionError("Directory path requires cnv calling app directory")
 
     # reset the ss_workflow_out_dir to not contain the cnv calling path
-    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
-
-    print(cnv_calling_dir)
-    print(ss_workflow_out_dir)
-
+    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0] + "/"
 
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -18,7 +18,8 @@ from general_functions import (
     parse_genepanels,
     get_sample_ids_from_sample_sheet,
     gather_sample_sheet,
-    get_stage_input_file_list
+    get_stage_input_file_list,
+    find_app_dir
 )
 
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -154,23 +154,23 @@ def run_cnvreports(
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
 
-    # sometimes the backlash maybe provided and we don't want that
-    if ss_workflow_out_dir.endswith("/"):
-        ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
+    # # sometimes the backlash maybe provided and we don't want that
+    # if ss_workflow_out_dir.endswith("/"):
+    #     ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
 
-    # the directory provided on the path is full, up to the cnv calling app,
-    # lets split the directory up to dias_single and keep the cnvcalling
-    # app in another variable object
+    # # the directory provided on the path is full, up to the cnv calling app,
+    # # lets split the directory up to dias_single and keep the cnvcalling
+    # # app in another variable object
 
-    #get the cnv calling dir name
-    cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
-    # need to ensure that the cnv calling app dir is in the directory
-    # given on the cmd line
-    if 'GATKgCNV_call' not in cnv_calling_dir:
-        raise AssertionError("Directory path requires cnv calling app directory")
+    # #get the cnv calling dir name
+    # cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
+    # # need to ensure that the cnv calling app dir is in the directory
+    # # given on the cmd line
+    # if 'GATKgCNV_call' not in cnv_calling_dir:
+    #     raise AssertionError("Directory path requires cnv calling app directory")
 
-    # reset the ss_workflow_out_dir to not contain the cnv calling path
-    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0] + "/"
+    # # reset the ss_workflow_out_dir to not contain the cnv calling path
+    # ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0] + "/"
 
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -200,7 +200,7 @@ def run_cnvreports(
         sample2stage_input_dict[sample] = stage_input_dict
 
     # get the inputs for the given app-pattern
-    staging_dict = get_stage_inputs_inc_cnv_dir(
+    staging_dict = get_stage_inputs(
         ss_workflow_out_dir, sample2stage_input_dict, cnv_calling_dir
     )
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -153,7 +153,7 @@ def run_cnvreports(
     """
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
-        
+
     assert ss_workflow_out_dir.endswith("/"), (
         "Input directory must be full path (ends with /)")
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-from collections import defaultdict
 from collections import OrderedDict
 import json
 import subprocess
@@ -10,7 +9,6 @@ from general_functions import (
     get_workflow_stage_info,
     make_app_out_dirs,
     make_workflow_out_dir,
-    get_stage_inputs,
     prepare_batch_writing,
     create_batch_file,
     assess_batch_file,
@@ -18,44 +16,8 @@ from general_functions import (
     parse_genepanels,
     get_sample_ids_from_sample_sheet,
     gather_sample_sheet,
-    get_stage_input_file_list,
-    find_app_dir
+    get_stage_inputs_inc_cnv_dir
 )
-
-
-def get_stage_inputs_inc_cnv_dir(ss_workflow_out_dir, stage_input_dict, cnv_calling_dir):
-    """ Return dict with sample2stage2files
-
-    Args:
-        ss_workflow_out_dir (str): Directory of single workflow
-        stage_input_dict (dict): Dict of stage2app
-
-    Returns:
-        dict: Dict of sample2stage2file_list
-    """
-
-    # Allows me to not have to check if a key exists before creating an entry in the dict
-    # Example: dict[entry][sub-entry][list-entry].append(ele)
-    dict_res = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-
-    # type_input can be either "multi" or a sample id
-    for type_input in stage_input_dict:
-        # find the inputs for each stage using given app/pattern
-        for stage_input, stage_input_info in stage_input_dict[type_input].items():
-            if stage_input_info["app"] is "eggd_GATKgCNV_call":
-                stage_input_info["app"] = cnv_calling_dir
-            input_app_dir = find_app_dir(
-                ss_workflow_out_dir, stage_input_info["app"]
-            )
-            inputs = get_stage_input_file_list(
-                input_app_dir,
-                app_subdir=stage_input_info["subdir"],
-                filename_pattern=stage_input_info["pattern"].format(type_input)
-            )
-            dict_res[type_input][stage_input]["file_list"] = inputs
-
-    return dict_res
-
 
 def create_job_reports(rpt_out_dir, all_samples, job_dict):
     """ Create and upload a job report file where reports are categorised in:

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -154,20 +154,20 @@ def run_cnvreports(
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
     assert ss_workflow_out_dir.endswith("/"), (
-        "Input directory must be full path (ends with /)")   
+        "Input directory must be full path (ends with /)")
 
     # the directory provided on the path is full, up to the cnv calling app,
     # lets split the directory up to dias_single and keep the cnvcalling
     # app in another variable object
-    cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
+    #cnv_calling_dir = ss_workflow_out_dir.rsplit("/",1)[1]
     # need to ensure that the cnv calling app dir is in the directory
     # given on the cmd line
-    if 'GATKgCNV_call' in cnv_calling_dir:
-        print("yay")
-    else:
-        ("Directory path requires cnv calling app directory")
+    # if 'GATKgCNV_call' in cnv_calling_dir:
+    #     print("yay")
+    #else:
+    #    ("Directory path requires cnv calling app directory")
     # reset the ss_workflow_out_dir to not contain the cnv calling path
-    ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
+    #ss_workflow_out_dir = ss_workflow_out_dir.rsplit("/",1)[0]
 
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -243,7 +243,11 @@ def run_cnvreports(
 
         # get the headers and values from the staging inputs
         rpt_headers, rpt_values = prepare_batch_writing(
-            staging_dict, "cnvreports", assay_config, assay_config.cnv_rpt_dynamic_files
+            staging_dict, "cnvreports", assay_config.happy_stage_prefix,
+            assay_config.somalier_relate_stage_id,
+            assay_config.cnv_athena_stage_id,
+            assay_config.cnv_generate_workbook_stage_id,
+            assay_config.cnv_rea_dynamic_files
         )
 
         # manually add the headers for reanalysis vcf2xls/generate_bed

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -1,0 +1,361 @@
+#!/usr/bin/python
+
+from collections import OrderedDict
+import json
+import subprocess
+
+from general_functions import (
+    format_relative_paths,
+    get_workflow_stage_info,
+    make_app_out_dirs,
+    make_workflow_out_dir,
+    get_stage_inputs,
+    prepare_batch_writing,
+    create_batch_file,
+    assess_batch_file,
+    parse_manifest,
+    parse_genepanels,
+    get_sample_ids_from_sample_sheet,
+    gather_sample_sheet
+)
+
+
+def create_job_reports(rpt_out_dir, all_samples, job_dict):
+    """ Create and upload a job report file where reports are categorised in:
+        - expected samples
+        - running jobs for samples found
+        - missing samples from the manifest
+        - samples with gene symbols as panels causing them to fail later on
+
+    Args:
+        rpt_out_dir (str): Dias reports directory
+        all_samples (list): List with all samples in sample sheet minus NA
+        job_dict (dict): Dict with the lists of samples for the categories
+        listed at the top of the docstring
+
+    Returns:
+        str: Name and path of job report file
+    """
+
+    # rpt_out_dir should always be /output/dias_single/dias_reports but in case
+    # someone adds a "/" at the end, which i do sometimes
+    name_file = [
+        ele for ele in rpt_out_dir.split('/') if ele.startswith("dias_reports")
+    ]
+
+    # there should only be one ele in name_file
+    job_report = "{}.txt".format(name_file[0])
+
+    # get samples for which a report is expected but the job will not started
+    # for reasons other than absence from manifest
+    # i.e. present in sample sheet but fastqs were not provided
+    difference_expected_starting = set(all_samples).difference(
+        set(job_dict["starting"])
+    )
+
+    with open(job_report, "w") as f:
+        f.write(
+            "Number of reports expected: {}\n\n".format(len(all_samples))
+        )
+
+        f.write(
+            "Number of samples for which a job started: {}\n".format(
+                len(job_dict["starting"])
+            )
+        )
+
+        f.write("Samples for which jobs didn't start:\n")
+
+        if difference_expected_starting:
+            for sample_id in difference_expected_starting:
+                f.write("{}\n".format(sample_id))
+
+        f.write(
+            "\nSamples not found in manifest: {}\n".format(
+                len(job_dict["missing_from_manifest"])
+            )
+        )
+
+        if job_dict["missing_from_manifest"]:
+            for sample_id in job_dict["missing_from_manifest"]:
+                f.write("{}\n".format(sample_id))
+
+        f.write(
+            "\nSamples booked with gene symbols: {}\n".format(
+                len(job_dict["symbols"])
+            )
+        )
+
+        if job_dict["symbols"]:
+            for sample_id, panels in job_dict["symbols"]:
+                f.write("{}\t{}\n".format(sample_id, panels))
+
+    cmd = "dx upload {} --path {}".format(job_report, rpt_out_dir)
+    subprocess.check_output(cmd, shell=True)
+
+    return "{}{}".format(rpt_out_dir, job_report)
+
+
+# reanalysis
+
+
+def run_reanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
+    reanalysis_dict = {}
+
+    # parse reanalysis file
+    with open(reanalysis_list) as r_fh:
+        for line in r_fh:
+            fields = line.strip().split("\t")
+            assert len(fields) == 2, (
+                "Unexpected number of fields in reanalysis_list. "
+                "File must contain one tab separated "
+                "sample/panel combination per line"
+            )
+            sample, panel = fields
+            panels = panel.split(";")
+
+            for panel in panels:
+                # get a dict of sample2panels
+                reanalysis_dict.setdefault(sample, set()).add(panel)
+
+    run_reports(
+        input_dir, dry_run, assay_config, assay_id,
+        reanalysis_dict=reanalysis_dict
+    )
+
+
+def run_reports(
+    ss_workflow_out_dir, dry_run, assay_config, assay_id, reanalysis_dict=None
+):
+    assert ss_workflow_out_dir.startswith("/"), (
+        "Input directory must be full path (starting at /)")
+    rpt_workflow_out_dir = make_workflow_out_dir(
+        assay_config.rpt_workflow_id, assay_id, ss_workflow_out_dir
+    )
+
+    rpt_workflow_stage_info = get_workflow_stage_info(
+        assay_config.rpt_workflow_id
+    )
+    rpt_output_dirs = make_app_out_dirs(
+        rpt_workflow_stage_info, rpt_workflow_out_dir
+    )
+
+    sample2stage_input_dict = {}
+
+    if reanalysis_dict:
+        stage_input_dict = assay_config.rea_stage_input_dict
+        sample_id_list = reanalysis_dict
+    else:
+        sample_sheet_path = gather_sample_sheet()
+        all_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
+        stage_input_dict = assay_config.rpt_stage_input_dict
+        sample_id_list = all_samples
+
+    # put the sample id in a dictionary so that the stage inputs can be
+    # assigned to a sample id
+    for sample in sample_id_list:
+        sample2stage_input_dict[sample] = stage_input_dict
+
+    # get the inputs for the given app-pattern
+    staging_dict = get_stage_inputs(
+        ss_workflow_out_dir, sample2stage_input_dict
+    )
+
+    # list that is going to represent the header in the batch tsv file
+    headers = []
+    # list that is going to represent the lines for each sample in the batch
+    # tsv file
+    values = []
+
+    if reanalysis_dict:
+        genepanels_data = parse_genepanels(assay_config.genepanels_file)
+
+        # get the headers and values from the staging inputs
+        rea_headers, rea_values = prepare_batch_writing(
+            staging_dict, "reports", assay_config,
+            assay_config.rea_dynamic_files
+        )
+
+        # manually add the headers for reanalysis vcf2xls/generate_bed
+        # rea_headers contains the headers for the batch file
+        for header in rea_headers:
+            new_headers = [field for field in header]
+            new_headers.append(
+                "{}.clinical_indication".format(
+                    assay_config.generate_workbook_stage_id
+                )
+            )
+            new_headers.append(
+                "{}.panel".format(
+                    assay_config.generate_workbook_stage_id
+                )
+            )
+            new_headers.append(
+                "{}.panel".format(assay_config.generate_bed_vep_stage_id)
+            )
+            new_headers.append(
+                "{}.panel".format(assay_config.generate_bed_athena_stage_id)
+            )
+            headers.append(tuple(new_headers))
+
+        # manually add the values for reanalysis workbook/generate_bed
+        # rea_values contains the values for the headers for the batch file
+        for line in rea_values:
+            # get all clinical_indications in a string and store it in a list
+            # with one ele
+            clinical_indications = [
+                ";".join(panel) for sample, panel in reanalysis_dict.items()
+                if line[0] == sample
+            ]
+            # clinical indications for generate_workbook
+            line.extend(clinical_indications)
+
+            # gather panels from clinical indications for displaying in
+            # generate_workbook
+            for sample, cis_in_reanalysis_file in reanalysis_dict.items():
+                if line[0] == sample:
+                    display_panel_list = []
+
+                    # gather every panel associated with the clinical
+                    # indication. Also gather HGNC ids specified in the
+                    # reanalysis file
+                    for ci in cis_in_reanalysis_file:
+                        if not ci.startswith("_"):
+                            display_panel_list.append(
+                                ";".join(genepanels_data[ci])
+                            )
+                        else:
+                            display_panel_list.append(ci)
+
+            line.append(";".join(display_panel_list))
+
+            # add clinical_indications for generate_bed_vep and
+            # generate_bed_athena
+            line.extend(clinical_indications)
+            line.extend(clinical_indications)
+            values.append(line)
+    else:
+        job_dict = {"starting": [], "missing_from_manifest": [], "symbols": []}
+
+        manifest_data = parse_manifest(assay_config.bioinformatic_manifest)
+
+        # get the headers and values from the staging inputs
+        rpt_headers, rpt_values = prepare_batch_writing(
+            staging_dict, "reports", assay_config, assay_config.rpt_dynamic_files
+        )
+
+        # manually add the headers for reanalysis vcf2xls/generate_bed
+        # rea_headers contains the headers for the batch file
+        for header in rpt_headers:
+            new_headers = [field for field in header]
+            new_headers.append(
+                "{}.clinical_indication".format(assay_config.generate_workbook_stage_id)
+            )
+            new_headers.append(
+                "{}.panel".format(assay_config.generate_workbook_stage_id)
+            )
+            headers.append(tuple(new_headers))
+
+        for line in rpt_values:
+            # sample id is the first element of every list according to
+            # the prepare_batch_writing function
+            sample_id = line[0]
+
+            if sample_id in manifest_data:
+                cis = manifest_data[sample_id]["clinical_indications"]
+                panels = manifest_data[sample_id]["panels"]
+
+                # get single genes with the sample
+                single_genes = [
+                    panel for panel in panels if panel.startswith("_")
+                ]
+
+                # if there are single genes
+                if single_genes:
+                    # check if they are HGNC ids
+                    symbols = [gene.startswith("_HGNC") for gene in single_genes]
+
+                    # if they are not, assume it is gene symbols or at least
+                    # something is going on and needs checking
+                    if not all(symbols):
+                        job_dict["symbols"].append(
+                            (sample_id, ";".join(cis))
+                        )
+                        continue
+
+                job_dict["starting"].append(sample_id)
+                # join up potential lists of cis and panels to align the batch
+                # file properly
+                cis = ";".join(cis)
+                panels = ";".join(panels)
+                line.append(cis)
+                line.append(panels)
+                values.append(line)
+            else:
+                job_dict["missing_from_manifest"].append(sample_id)
+
+        report_file = create_job_reports(
+            rpt_workflow_out_dir, all_samples, job_dict
+        )
+
+        print("Created and uploaded job report file: {}".format(report_file))
+
+    rpt_batch_file = create_batch_file(headers, values)
+
+    args = ""
+    args += "-i{}.flank={} ".format(
+        assay_config.generate_bed_vep_stage_id, assay_config.xlsx_flanks
+    )
+
+    args += "-i{}.config_file={} ".format(
+        assay_config.vep_stage_id, assay_config.vep_config
+    )
+
+    if assay_config.assay_name == "TWE":
+        args += "-i{}.buffer_size=1000".format(assay_config.vep_stage_id)
+
+    command = "dx run -y --rerun-stage '*' {} {} --batch-tsv={}".format(
+        assay_config.rpt_workflow_id, args, rpt_batch_file
+    )
+
+    # assign stage out folders
+    app_relative_paths = format_relative_paths(rpt_workflow_stage_info)
+    destination = " --destination={} ".format(rpt_workflow_out_dir)
+
+    command = " ".join([command, app_relative_paths, destination])
+
+    if dry_run:
+        print("Created workflow dir: {}".format(rpt_workflow_out_dir))
+        print("Stage info:")
+        print(json.dumps(
+            OrderedDict(sorted(rpt_workflow_stage_info.iteritems())), indent=2)
+        )
+        print("Inputs gathered:")
+        print(json.dumps(staging_dict, indent=4))
+        print("Created apps out dir: {}")
+        print(json.dumps(
+            OrderedDict(sorted(rpt_output_dirs.iteritems())), indent=4)
+        )
+        print("Created batch tsv: {}".format(rpt_batch_file))
+
+        check_batch_file = assess_batch_file(rpt_batch_file)
+
+        if check_batch_file is True:
+            print(
+                "{}: Format of the file is correct".format(rpt_batch_file)
+            )
+        else:
+            print((
+                "Number of columns in header doesn't match "
+                "nb of columns in values at line {}".format(check_batch_file)
+            ))
+
+        print("Format of stage output dirs: {}".format(app_relative_paths))
+        print("Final cmd ran: {}".format(command))
+        print("Deleting '{}' as part of the dry-run".format(rpt_workflow_out_dir))
+        delete_folders_cmd = "dx rm -r {}".format(rpt_workflow_out_dir)
+        subprocess.call(delete_folders_cmd, shell=True)
+    else:
+        subprocess.call(command, shell=True)
+
+    return rpt_workflow_out_dir

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -43,6 +43,9 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
         ele for ele in rpt_out_dir.split('/') if ele.startswith("dias_cnvreports")
     ]
     # there should only be one ele in name_file
+    if len(name_file) != 1:
+        raise Exception("reports output directory '{}' contains two "
+                        "dias_cnvreports".format(rpt_out_dir))
     job_report = "{}.txt".format(name_file[0])
 
     # get samples for which a report is expected but the job will not started

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -170,6 +170,7 @@ def run_cnvreports(
     rpt_workflow_out_dir = make_workflow_out_dir(
         assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir
     )
+    print(rpt_workflow_out_dir)
 
     rpt_workflow_stage_info = get_workflow_stage_info(
         assay_config.cnv_rpt_workflow_id

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -130,11 +130,11 @@ def run_reports(
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
     rpt_workflow_out_dir = make_workflow_out_dir(
-        assay_config.rpt_workflow_id, assay_id, ss_workflow_out_dir
+        assay_config.cnv_rpt_workflow_id, assay_id, ss_workflow_out_dir
     )
 
     rpt_workflow_stage_info = get_workflow_stage_info(
-        assay_config.rpt_workflow_id
+        assay_config.cnv_rpt_workflow_id
     )
     rpt_output_dirs = make_app_out_dirs(
         rpt_workflow_stage_info, rpt_workflow_out_dir
@@ -143,12 +143,12 @@ def run_reports(
     sample2stage_input_dict = {}
 
     if reanalysis_dict:
-        stage_input_dict = assay_config.rea_stage_input_dict
+        stage_input_dict = assay_config.cnv_rea_stage_input_dict
         sample_id_list = reanalysis_dict
     else:
         sample_sheet_path = gather_sample_sheet()
         all_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
-        stage_input_dict = assay_config.rpt_stage_input_dict
+        stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples
 
     # put the sample id in a dictionary so that the stage inputs can be
@@ -173,7 +173,7 @@ def run_reports(
         # get the headers and values from the staging inputs
         rea_headers, rea_values = prepare_batch_writing(
             staging_dict, "reports", assay_config,
-            assay_config.rea_dynamic_files
+            assay_config.cnv_rea_dynamic_files
         )
 
         # manually add the headers for reanalysis vcf2xls/generate_bed
@@ -182,19 +182,19 @@ def run_reports(
             new_headers = [field for field in header]
             new_headers.append(
                 "{}.clinical_indication".format(
-                    assay_config.generate_workbook_stage_id
+                    assay_config.cnv_generate_workbook_stage_id
                 )
             )
             new_headers.append(
                 "{}.panel".format(
-                    assay_config.generate_workbook_stage_id
+                    assay_config.cnv_generate_workbook_stage_id
                 )
             )
             new_headers.append(
-                "{}.panel".format(assay_config.generate_bed_vep_stage_id)
+                "{}.panel".format(assay_config.cnv_generate_workbook_stage_id)
             )
             new_headers.append(
-                "{}.panel".format(assay_config.generate_bed_athena_stage_id)
+                "{}.panel".format(assay_config.cnv_generate_workbook_stage_id)
             )
             headers.append(tuple(new_headers))
 
@@ -241,7 +241,7 @@ def run_reports(
 
         # get the headers and values from the staging inputs
         rpt_headers, rpt_values = prepare_batch_writing(
-            staging_dict, "reports", assay_config, assay_config.rpt_dynamic_files
+            staging_dict, "reports", assay_config, assay_config.cnv_rpt_dynamic_files
         )
 
         # manually add the headers for reanalysis vcf2xls/generate_bed
@@ -249,10 +249,10 @@ def run_reports(
         for header in rpt_headers:
             new_headers = [field for field in header]
             new_headers.append(
-                "{}.clinical_indication".format(assay_config.generate_workbook_stage_id)
+                "{}.clinical_indication".format(assay_config.cnv_generate_workbook_stage_id)
             )
             new_headers.append(
-                "{}.panel".format(assay_config.generate_workbook_stage_id)
+                "{}.panel".format(assay_config.cnv_generate_workbook_stage_id)
             )
             headers.append(tuple(new_headers))
 
@@ -304,18 +304,18 @@ def run_reports(
 
     args = ""
     args += "-i{}.flank={} ".format(
-        assay_config.generate_bed_vep_stage_id, assay_config.xlsx_flanks
+        assay_config.cnv_generate_vep_stage_id, assay_config.xlsx_flanks
     )
 
     args += "-i{}.config_file={} ".format(
-        assay_config.vep_stage_id, assay_config.vep_config
+        assay_config.cnv_vep_stage_id, assay_config.cnv_vep_config
     )
 
     if assay_config.assay_name == "TWE":
         args += "-i{}.buffer_size=1000".format(assay_config.vep_stage_id)
 
     command = "dx run -y --rerun-stage '*' {} {} --batch-tsv={}".format(
-        assay_config.rpt_workflow_id, args, rpt_batch_file
+        assay_config.cnv_rpt_workflow_id, args, rpt_batch_file
     )
 
     # assign stage out folders

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -99,7 +99,7 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
 # reanalysis
 
 
-def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
+def cnv_run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
     reanalysis_dict = {}
 
     # parse reanalysis file
@@ -124,7 +124,7 @@ def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_lis
     )
 
 
-def run_cnvreports(
+def cnv_run_cnvreports(
     ss_workflow_out_dir, dry_run, assay_config, assay_id, reanalysis_dict=None
 ):
     assert ss_workflow_out_dir.startswith("/"), (

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -42,9 +42,7 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
         ele for ele in rpt_out_dir.split('/') if ele.startswith("dias_cnvreports")
     ]
     # there should only be one ele in name_file
-    if len(name_file) != 1:
-        raise Exception("reports output directory '{}' contains two "
-                        "dias_cnvreports".format(rpt_out_dir))
+    assert len(name_file) == 1, "reports output directory '{}' contains two dias_cnvreports".format(rpt_out_dir)
     job_report = "{}.txt".format(name_file[0])
 
     # get samples for which a report is expected but the job will not started

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -173,7 +173,7 @@ def run_cnvreports(
         rea_headers, rea_values = prepare_batch_writing(
             staging_dict, "cnvreports", assay_config.happy_stage_prefix,
             assay_config.somalier_relate_stage_id,
-            assay_config.cnv_athena_stage_id,
+            "",
             assay_config.cnv_generate_workbook_stage_id,
             assay_config.cnv_rea_dynamic_files
         )
@@ -245,7 +245,7 @@ def run_cnvreports(
         rpt_headers, rpt_values = prepare_batch_writing(
             staging_dict, "cnvreports", assay_config.happy_stage_prefix,
             assay_config.somalier_relate_stage_id,
-            assay_config.cnv_athena_stage_id,
+            "",
             assay_config.cnv_generate_workbook_stage_id,
             assay_config.cnv_rea_dynamic_files
         )

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -247,7 +247,7 @@ def run_cnvreports(
             assay_config.somalier_relate_stage_id,
             "",
             assay_config.cnv_generate_workbook_stage_id,
-            assay_config.cnv_rea_dynamic_files
+            assay_config.cnv_rpt_dynamic_files
         )
 
         # manually add the headers for reanalysis vcf2xls/generate_bed

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -171,7 +171,10 @@ def run_cnvreports(
 
         # get the headers and values from the staging inputs
         rea_headers, rea_values = prepare_batch_writing(
-            staging_dict, "reports", assay_config,
+            staging_dict, "cnvreports", assay_config.happy_stage_prefix,
+            assay_config.somalier_relate_stage_id,
+            assay_config.cnv_athena_stage_id,
+            assay_config.cnv_generate_workbook_stage_id,
             assay_config.cnv_rea_dynamic_files
         )
 
@@ -292,7 +295,7 @@ def run_cnvreports(
                 values.append(line)
             else:
                 job_dict["missing_from_manifest"].append(sample_id)
-                
+
         report_file = create_job_reports(
             rpt_workflow_out_dir, all_samples, job_dict
         )

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -153,6 +153,8 @@ def run_cnvreports(
     """
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
+    assert ss_workflow_out_dir.endswith("/"), (
+        "Input directory must be full path (ends with /)")   
 
     # the directory provided on the path is full, up to the cnv calling app,
     # lets split the directory up to dias_single and keep the cnvcalling

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -16,7 +16,6 @@ from general_functions import (
     parse_genepanels,
     get_sample_ids_from_sample_sheet,
     gather_sample_sheet,
-    get_stage_inputs_inc_cnv_dir,
     get_stage_inputs
 )
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -99,7 +99,7 @@ def create_job_reports(rpt_out_dir, all_samples, job_dict):
 # reanalysis
 
 
-def cnv_run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
+def run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis_list):
     reanalysis_dict = {}
 
     # parse reanalysis file
@@ -124,7 +124,7 @@ def cnv_run_cnvreanalysis(input_dir, dry_run, assay_config, assay_id, reanalysis
     )
 
 
-def cnv_run_cnvreports(
+def run_cnvreports(
     ss_workflow_out_dir, dry_run, assay_config, assay_id, reanalysis_dict=None
 ):
     assert ss_workflow_out_dir.startswith("/"), (

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from collections import defaultdict
 from collections import OrderedDict
 import json
 import subprocess

--- a/dias.py
+++ b/dias.py
@@ -78,6 +78,20 @@ def main():
     )
     parser_r.set_defaults(which='cnvreports')
 
+    parser_r = subparsers.add_parser('cnvreanalysis', help='cnvreanalysis help')
+    parser_r.add_argument(
+        'input_dir', type=str,
+        help='A single/multi sample workflow output directory path'
+    )
+    parser_r.add_argument(
+        'cnvreanalysis_list', type=str,
+        help=(
+            'Tab delimited file containing sample and panel for cnvreanalysis'
+            '. One sample/panel combination per line'
+        )
+    )
+    parser_r.set_defaults(which='cnvreanalysis')
+
     parser_r = subparsers.add_parser('reports', help='reports help')
     parser_r.add_argument(
         'input_dir', type=str,

--- a/dias.py
+++ b/dias.py
@@ -8,7 +8,7 @@ from single_workflow import run_ss_workflow
 from multi_workflow import run_ms_workflow
 from multiqc import run_multiqc_app
 from cnvcalling import run_cnvcall_app
-from cnvreports import run_reports, run_reanalysis
+from cnvreports import run_cnvreports, run_cnvreanalysis
 from reports import run_reports, run_reanalysis
 from general_functions import get_latest_config
 
@@ -160,7 +160,11 @@ def main():
             args.sample_list
         )
     elif workflow == "cnvreports":
-        reports_out_dir = run_reports(
+        cnv_reports_out_dir = run_cnvreports(
+            args.input_dir, args.dry_run, config, assay_id
+        )
+    elif workflow == "cnvreanalysis":
+        cnv_reports_out_dir = run_cnvreanalysis(
             args.input_dir, args.dry_run, config, assay_id
         )
     elif workflow == "reports":

--- a/dias.py
+++ b/dias.py
@@ -179,7 +179,8 @@ def main():
         )
     elif workflow == "cnvreanalysis":
         cnv_reports_out_dir = run_cnvreanalysis(
-            args.input_dir, args.dry_run, config, assay_id
+            args.input_dir, args.dry_run, config, assay_id,
+            args.cnvreanalysis_list
         )
     elif workflow == "reports":
         reports_out_dir = run_reports(

--- a/dias.py
+++ b/dias.py
@@ -8,6 +8,7 @@ from single_workflow import run_ss_workflow
 from multi_workflow import run_ms_workflow
 from multiqc import run_multiqc_app
 from cnvcalling import run_cnvcall_app
+from cnvreports import run_reports, run_reanalysis
 from reports import run_reports, run_reanalysis
 from general_functions import get_latest_config
 
@@ -69,6 +70,13 @@ def main():
         )
     )
     parser_n.set_defaults(which='cnvcall')
+
+    parser_r = subparsers.add_parser('cnvreports', help='cnvreports help')
+    parser_r.add_argument(
+        'input_dir', type=str,
+        help='A single/multi sample workflow output directory path'
+    )
+    parser_r.set_defaults(which='cnvreports')
 
     parser_r = subparsers.add_parser('reports', help='reports help')
     parser_r.add_argument(
@@ -150,6 +158,10 @@ def main():
         cnvcall_applet_out_dir = run_cnvcall_app(
             args.input_dir, args.dry_run, config, assay_id,
             args.sample_list
+        )
+    elif workflow == "cnvreports":
+        reports_out_dir = run_reports(
+            args.input_dir, args.dry_run, config, assay_id
         )
     elif workflow == "reports":
         reports_out_dir = run_reports(

--- a/general_functions.py
+++ b/general_functions.py
@@ -391,6 +391,10 @@ def prepare_batch_writing(
     Args:
         stage_input_dict (dict): Dict of sample2stage2file_list
         type_workflow (str): String equal to either multi or reports
+        assay_config_happy_stage_prefix (str): Hap.py stage id from the assay config
+        assay_config_somalier_relate_stage_id (str): Somalier relate stage id from the assay config
+        assay_config_athena_stage_id (str): Athena stage id from the assay config
+        assay_config_generate_workbook_stage_id (str): workbooks stage id from the assay config
         workflow_specificity (dict, optional): For the reports, add the dynamic files to headers + values. Defaults to {}.
 
     Returns:

--- a/general_functions.py
+++ b/general_functions.py
@@ -355,41 +355,9 @@ def get_stage_inputs(ss_workflow_out_dir, stage_input_dict, cnv_calling_dir=None
     Args:
         ss_workflow_out_dir (str): Directory of single workflow
         stage_input_dict (dict): Dict of stage2app
-
-    Returns:
-        dict: Dict of sample2stage2file_list
-    """
-
-    # Allows me to not have to check if a key exists before creating an entry in the dict
-    # Example: dict[entry][sub-entry][list-entry].append(ele)
-    dict_res = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
-
-    # type_input can be either "multi" or a sample id
-    for type_input in stage_input_dict:
-        # find the inputs for each stage using given app/pattern
-        for stage_input, stage_input_info in stage_input_dict[type_input].items():
-            if stage_input_info["app"] is "eggd_GATKgCNV_call":
-                stage_input_info["app"] = cnv_calling_dir
-            input_app_dir = find_app_dir(
-                ss_workflow_out_dir, stage_input_info["app"]
-            )
-            inputs = get_stage_input_file_list(
-                input_app_dir,
-                app_subdir=stage_input_info["subdir"],
-                filename_pattern=stage_input_info["pattern"].format(type_input)
-            )
-            dict_res[type_input][stage_input]["file_list"] = inputs
-
-    return dict_res
-
-def get_stage_inputs_inc_cnv_dir(ss_workflow_out_dir, stage_input_dict, cnv_calling_dir):
-    """ Return dict with sample2stage2files ffor CNV reports
-
-    Args:
-        ss_workflow_out_dir (str): Directory of single workflow
-        stage_input_dict (dict): Dict of stage2app
         cnv_calling_dir (str): The CNV calling app output folder from cmd line
 
+
     Returns:
         dict: Dict of sample2stage2file_list
     """
@@ -415,6 +383,7 @@ def get_stage_inputs_inc_cnv_dir(ss_workflow_out_dir, stage_input_dict, cnv_call
             dict_res[type_input][stage_input]["file_list"] = inputs
 
     return dict_res
+
 
 def prepare_batch_writing(
     stage_input_dict, type_workflow, assay_config_happy_stage_prefix,

--- a/general_functions.py
+++ b/general_functions.py
@@ -743,6 +743,38 @@ def gather_sample_sheet():
 
     return sample_sheets[0]["id"]
 
+def find_files(project_name, app_dir, pattern="."):
+    """Searches for files ending in provided pattern (bam/bai) in a
+    given path (single).
+
+    Args:
+        app_dir (str): single path including directory to output app.
+        pattern (str): searchs for files ending in given pattern.
+        Defaults to ".".
+        project_name (str): The project name on DNAnexus
+
+    Returns:
+        search_result: list containing files ending in given pattern
+        of every sample processed in single.
+    """
+    projectID  = list(dxpy.bindings.search.find_projects(name=project_name))[0]['id']
+    # the pattern is usually "-E 'pattern'" and we dont want the -E part
+    pattern = pattern.split('-E ')[1].replace("'", "")
+    search_result = []
+
+    try:
+        for file in dxpy.bindings.search.find_data_objects(
+            project=projectID, folder=app_dir,classname="file",
+            name=pattern, name_mode="regexp", describe=True
+            ):
+            search_result.append(file["describe"]["name"])
+    except ValueError:
+        print('Could not files {} in {}'.format(
+              pattern,app_dir
+            ))
+
+    return search_result
+
 def make_app_output_dir(app_id, ss_workflow_out_dir, app_name, assay_id):
     """Creates directory for single app with version, date and attempt
 

--- a/general_functions.py
+++ b/general_functions.py
@@ -383,8 +383,8 @@ def get_stage_inputs(ss_workflow_out_dir, stage_input_dict):
 
 def prepare_batch_writing(
     stage_input_dict, type_workflow, assay_config_happy_stage_prefix,
-    assay_config_somalier_relate_stage_id, workflow_specificity={},
-    assay_config_athena_stage_id, assay_config_generate_workbook_stage_id
+    assay_config_somalier_relate_stage_id,assay_config_athena_stage_id,
+    assay_config_generate_workbook_stage_id, workflow_specificity={}
 ):
     """ Return headers and values for the batch file writing
 

--- a/general_functions.py
+++ b/general_functions.py
@@ -349,7 +349,7 @@ def make_workflow_out_dir(workflow_id, assay_id, workflow_out_dir="/output/"):
     return None
 
 
-def get_stage_inputs(ss_workflow_out_dir, stage_input_dict):
+def get_stage_inputs(ss_workflow_out_dir, stage_input_dict, cnv_calling_dir=None):
     """ Return dict with sample2stage2files
 
     Args:
@@ -368,6 +368,8 @@ def get_stage_inputs(ss_workflow_out_dir, stage_input_dict):
     for type_input in stage_input_dict:
         # find the inputs for each stage using given app/pattern
         for stage_input, stage_input_info in stage_input_dict[type_input].items():
+            if stage_input_info["app"] is "eggd_GATKgCNV_call":
+                stage_input_info["app"] = cnv_calling_dir
             input_app_dir = find_app_dir(
                 ss_workflow_out_dir, stage_input_info["app"]
             )

--- a/general_functions.py
+++ b/general_functions.py
@@ -441,6 +441,34 @@ def prepare_batch_writing(
             # add the value of output prefix to generate workbooks
             values.append("{}_{}".format(sample_id, index_to_use))
 
+        elif type_workflow == "cnvreports":
+            # renaming type_input for comprehension in this elif
+            sample_id = type_input
+
+            if sample_id.startswith("NA"):
+                continue
+
+            values.append(sample_id)
+
+            # get the index for the coverage report that needs to be created
+            coverage_reports = find_previous_reports(
+                sample_id, "coverage_report.html"
+            )
+            # get the index for the xls report that needs to be created
+            xls_reports = find_previous_reports(sample_id, ".xls")
+            xls_index = get_next_index(xls_reports)
+            coverage_index = get_next_index(coverage_reports)
+
+            index_to_use = max([xls_index, coverage_index])
+
+            # add the name output_prefix to generate_workbooks
+            headers.append("{}.output_prefix".format(
+                    assay_config.cnv_generate_workbook_stage_id
+                )
+            )
+            # add the value of output prefix to generate workbooks
+            values.append("{}_{}".format(sample_id, index_to_use))
+
         # add the dynamic files to the headers and values
         for stage, file_id in workflow_specificity.items():
             headers.append(stage)  # col for file name

--- a/general_functions.py
+++ b/general_functions.py
@@ -382,7 +382,9 @@ def get_stage_inputs(ss_workflow_out_dir, stage_input_dict):
 
 
 def prepare_batch_writing(
-    stage_input_dict, type_workflow, assay_config, workflow_specificity={}
+    stage_input_dict, type_workflow, assay_config_happy_stage_prefix,
+    assay_config_somalier_relate_stage_id, workflow_specificity={},
+    assay_config_athena_stage_id, assay_config_generate_workbook_stage_id
 ):
     """ Return headers and values for the batch file writing
 
@@ -406,10 +408,10 @@ def prepare_batch_writing(
         if type_workflow == "multi":
             values.append("multi")
             # Hap.py - static values
-            headers.append(assay_config.happy_stage_prefix)
+            headers.append(assay_config_happy_stage_prefix)
             values.append("NA12878")
 
-        elif type_workflow == "reports":
+        elif type_workflow == "reports" or type_workflow == "cnvreports":
             # renaming type_input for comprehension in this elif
             sample_id = type_input
 
@@ -430,42 +432,14 @@ def prepare_batch_writing(
             index_to_use = max([xls_index, coverage_index])
 
             # add the name param to athena
-            headers.append("{}.name".format(assay_config.athena_stage_id))
+            headers.append("{}.name".format(assay_config_athena_stage_id))
             # add the name output_prefix to generate_workbooks
             headers.append("{}.output_prefix".format(
-                    assay_config.generate_workbook_stage_id
+                    assay_config_generate_workbook_stage_id
                 )
             )
             # add the value of name to athena
             values.append("{}_{}".format(sample_id, index_to_use))
-            # add the value of output prefix to generate workbooks
-            values.append("{}_{}".format(sample_id, index_to_use))
-
-        elif type_workflow == "cnvreports":
-            # renaming type_input for comprehension in this elif
-            sample_id = type_input
-
-            if sample_id.startswith("NA"):
-                continue
-
-            values.append(sample_id)
-
-            # get the index for the coverage report that needs to be created
-            coverage_reports = find_previous_reports(
-                sample_id, "coverage_report.html"
-            )
-            # get the index for the xls report that needs to be created
-            xls_reports = find_previous_reports(sample_id, ".xls")
-            xls_index = get_next_index(xls_reports)
-            coverage_index = get_next_index(coverage_reports)
-
-            index_to_use = max([xls_index, coverage_index])
-
-            # add the name output_prefix to generate_workbooks
-            headers.append("{}.output_prefix".format(
-                    assay_config.cnv_generate_workbook_stage_id
-                )
-            )
             # add the value of output prefix to generate workbooks
             values.append("{}_{}".format(sample_id, index_to_use))
 
@@ -484,7 +458,7 @@ def prepare_batch_writing(
 
             # One file in file list - no need to merge into array
             if len(stage_data[stage_input]["file_list"]) == 1:
-                if "{}".format(assay_config.somalier_relate_stage_id) in stage_input:
+                if "{}".format(assay_config_somalier_relate_stage_id) in stage_input:
                     file_ids = stage_data[stage_input]["file_list"]
                 else:
                     file_ids = stage_data[stage_input]["file_list"][0]

--- a/general_functions.py
+++ b/general_functions.py
@@ -716,7 +716,8 @@ def gather_sample_sheet():
 
 def find_files(project_name, app_dir, pattern="."):
     """Searches for files ending in provided pattern (e.g "*bam") in a
-    given path (single).
+    given path that contains the files that are being searched for
+   (e.g /output/single/sentieon_output).
 
     Args:
         app_dir (str): single path including directory to output app.

--- a/general_functions.py
+++ b/general_functions.py
@@ -715,7 +715,7 @@ def gather_sample_sheet():
     return sample_sheets[0]["id"]
 
 def find_files(project_name, app_dir, pattern="."):
-    """Searches for files ending in provided pattern (bam/bai) in a
+    """Searches for files ending in provided pattern (e.g "*bam") in a
     given path (single).
 
     Args:

--- a/general_functions.py
+++ b/general_functions.py
@@ -431,15 +431,22 @@ def prepare_batch_writing(
 
             index_to_use = max([xls_index, coverage_index])
 
-            # add the name param to athena
-            headers.append("{}.name".format(assay_config_athena_stage_id))
+            # CNV reports currently does not have athena so we skip adding
+            # athena headers if its cnvreports
+            if type_workflow != "cnvreports":
+                # add the name param to athena
+                headers.append("{}.name".format(assay_config_athena_stage_id))
+
             # add the name output_prefix to generate_workbooks
             headers.append("{}.output_prefix".format(
                     assay_config_generate_workbook_stage_id
                 )
             )
-            # add the value of name to athena
-            values.append("{}_{}".format(sample_id, index_to_use))
+
+            if type_workflow != "cnvreports":
+                # add the value of name to athena
+                values.append("{}_{}".format(sample_id, index_to_use))
+
             # add the value of output prefix to generate workbooks
             values.append("{}_{}".format(sample_id, index_to_use))
 


### PR DESCRIPTION
- New `cnvreports.py` script to handle CNV report and reanalysis generation. Very similar to `reports.py` but using different stage IDs from CEN Config (refer new stage IDs here: https://github.com/eastgenomics/egg5_dias_CEN_config/blob/CNV_integration_dev/egg5_config.py)

- Modification of `prepare_batch_writing` function to remove hardcoding of stage ID and flexibility of using function for CNVreports or reports (currently hard coded with athena stage IDs which isn't used in CNV reporting). This will require making changes to reports.py to update arg inputs for this function but will do this changes in the CNV_dev -> main PR later on :)

- Modified CNVcalling output folder to be `appname_appversion-assay_assayversion-date-attempt`

- Modification of `get_stage_inputs` to allow the specific CNV calling app output path to searched rather than a generic app name output.


Reports job: https://platform.dnanexus.com/projects/GFGYfjj4PygF2VvB4gvgyxQQ/monitor/analysis/GG8KQ9Q4PygJjPpy12gfkvyF
Reanalysis job: https://platform.dnanexus.com/projects/GFGYfjj4PygF2VvB4gvgyxQQ/monitor/analysis/GG8KPF84PygK1XVy3QPK3f93

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/81)
<!-- Reviewable:end -->
