### PR TITLE
GCNV-96 dias batch v1.10.2 CNVcalling amendments

### DIFF
--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -93,9 +93,9 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
         file_ids,
         project_name, app_output_dir
     )
-
     # upload excluded regions file
-    cmd = "dx upload {} --path {}".format(excluded_sample_list, app_output_dir)
+    excluded_list_path = app_output_dir + "/" + "excluded_list.tsv"
+    cmd = "dx upload {} --path {}".format(excluded_sample_list, excluded_list_path)
     subprocess.check_output(cmd, shell=True)
 
     if dry_run is True:

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -94,6 +94,10 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
         project_name, app_output_dir
     )
 
+    # upload excluded regions file
+    cmd = "dx upload {} --path {}".format(excluded_sample_list, app_output_dir)
+    subprocess.check_output(cmd, shell=True)
+
     if dry_run is True:
         print("Final cmd ran: {}".format(command))
     else:

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -69,7 +69,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
     # Get the first part of sample_names
     sample_names = [x.split('-')[0] for x in sample_names]
     # Remove bam/bai files of QC faild samples
-    sample_bambis = [x for x in bambi_files if x.split('-')[0] not in sample_names]
+    sample_bambis = [x for x in bambi_files if x.split('_')[0] not in sample_names]
 
     # Find the file-IDs of the passed bam/bai samples
     file_ids = ""

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -3,6 +3,7 @@ from ast import excepthandler
 import sys
 import subprocess
 import dxpy
+import re
 
 from general_functions import (
     get_dx_cwd_project_name,
@@ -65,24 +66,20 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
         with open(excluded_sample_list) as fh:
             for line in fh:  # line can be a sample name or sample tab panel name
                 sample_names.append(line.strip().split("\t")[0])
-    print(sample_names)
-    if any(sample in "EGG" for sample in sample_names):
-        print("Contains egg")
-    else:
-        print("Does not contain egg")
-    # Get the first part of sample_names
-    sample_names = [x.split('_')[0] for x in sample_names]
+
     # Check that the sample list is not just the first field but it
     # is until EGG
-    tested = [sample for sample in sample_names if "EGG" in sample ]
-
-    #try:
-    if any(sample in "EGG" for sample in sample_names):
-        print("Contains egg")
-    else:
-        print("Does not contain egg")
-    #except (ValueError, IndexError):
-    #    exit('Could not complete request.')
+    last_field = re.compile("-EGG[0-9]")
+    for sample in sample_names:
+        print(sample)
+        match = re.search(last_field, sample)
+        if match is None:
+            raise Exception("sample '{}' is not full sample name "
+                            "up to EGG code".format(
+                                sample
+                                ))
+    # Get the first part of sample_names
+    sample_names = [x.split('_')[0] for x in sample_names]
     # Remove bam/bai files of QC faild samples
     sample_bambis = [x for x in bambi_files if x.split('_')[0] not in sample_names]
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -66,6 +66,10 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
             for line in fh:  # line can be a sample name or sample tab panel name
                 sample_names.append(line.strip().split("\t")[0])
 
+    if any(sample in "EGG" for sample in sample_names):
+        print("Contains egg")
+    else:
+        print("Does not contain egg")
     # Get the first part of sample_names
     sample_names = [x.split('_')[0] for x in sample_names]
     # Check that the sample list is not just the first field but it

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -35,12 +35,11 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
     assert ss_workflow_out_dir.startswith("/"), (
         "Input directory must be full path (starting at /)")
     path_dirs = [x for x in ss_workflow_out_dir.split("/") if x]
-    ss_for_multiqc = [ele for ele in path_dirs if "single" in ele]
-    assert ss_for_multiqc != [], (
+    is_path_single = [ele for ele in path_dirs if "single" in ele]
+    assert is_path_single != [], (
         "Path '{}' is not an accepted directory, "
         "must contain 'single'".format(ss_workflow_out_dir)
     )
-    ss_for_multiqc = ss_for_multiqc[0]
 
     # Find the app name and create an output folder for it under ss
     app_name = get_object_attribute_from_object_id_or_path(

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -71,7 +71,6 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
     # is until EGG
     last_field = re.compile("-EGG[0-9]")
     for sample in sample_names:
-        print(sample)
         match = re.search(last_field, sample)
         if match is None:
             raise Exception("sample '{}' is not full sample name "

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -65,7 +65,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
         with open(excluded_sample_list) as fh:
             for line in fh:  # line can be a sample name or sample tab panel name
                 sample_names.append(line.strip().split("\t")[0])
-
+    print(sample_names)
     if any(sample in "EGG" for sample in sample_names):
         print("Contains egg")
     else:

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -67,7 +67,7 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
                 sample_names.append(line.strip().split("\t")[0])
 
     # Get the first part of sample_names
-    sample_names = [x.split('-')[0] for x in sample_names]
+    sample_names = [x.split('_')[0] for x in sample_names]
     # Remove bam/bai files of QC faild samples
     sample_bambis = [x for x in bambi_files if x.split('_')[0] not in sample_names]
 

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -76,9 +76,11 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
                             "up to EGG code".format(
                                 sample
                                 ))
-    # Get the first part of sample_names
+    # Keep the excluded sample name up to EGG and remove anything after 
+    # that which would be after "_". This is if the excluded list
+    # contains up full filenames up to .bam
     sample_names = [x.split('_')[0] for x in sample_names]
-    # Remove bam/bai files of QC faild samples
+    # Remove bam/bai files of QC failed samples
     sample_bambis = [x for x in bambi_files if x.split('_')[0] not in sample_names]
 
     # Find the file-IDs of the passed bam/bai samples

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -68,6 +68,17 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
 
     # Get the first part of sample_names
     sample_names = [x.split('_')[0] for x in sample_names]
+    # Check that the sample list is not just the first field but it
+    # is until EGG
+    tested = [sample for sample in sample_names if "EGG" in sample ]
+
+    #try:
+    if any(sample in "EGG" for sample in sample_names):
+        print("Contains egg")
+    else:
+        print("Does not contain egg")
+    #except (ValueError, IndexError):
+    #    exit('Could not complete request.')
     # Remove bam/bai files of QC faild samples
     sample_bambis = [x for x in bambi_files if x.split('_')[0] not in sample_names]
 


### PR DESCRIPTION
### Upload excluded samples tsv to output folder
Samples can be excluded from CNV calling and this is provided in a tsv when running dias batch. This file will be uploaded into the CNV calling app directory and named "excluded_list.tsv".

### Use the full sample name in the excluded list
The full sample name is needed to differentiate the samples if there are repeated ones. Currently, only the first field is used. Now, the full sample name will be used up to EGG. If a sample in the excluded list does not have EGG, an error will be raised.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/89)
<!-- Reviewable:end -->
