### PR TITLE
GCNV-96 dias batch v1.10.2 CNVreports amendments

### DIFF
--- a/cnvreports.py
+++ b/cnvreports.py
@@ -198,7 +198,6 @@ def run_cnvreports(
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
         # Keep the samplesheet samples that have a CNV reports
         all_samples =set(samplesheet_samples).intersection(cnv_samples)
-        all_samples = cnv_samples
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -198,7 +198,6 @@ def run_cnvreports(
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
         # Keep the samplesheet samples that have a CNV reports
         all_samples =set(samplesheet_samples).intersection(cnv_samples)
-        print(all_samples)
         all_samples = cnv_samples
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -196,7 +196,7 @@ def run_cnvreports(
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
         print(samplesheet_samples)
         print(cnv_samples)
-        all_samples = samplesheet_samples - cnv_samples
+        all_samples =set(samplesheet_samples).intersection(cnv_samples)
         print(all_samples)
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -188,6 +188,7 @@ def run_cnvreports(
     else:
         sample_sheet_path = gather_sample_sheet()
         all_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
+        print(all_samples)
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -195,10 +195,11 @@ def run_cnvreports(
         cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
         cnv_samples = [str(x) for x in cnv_samples]
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
-        print(samplesheet_samples)
+        #print(samplesheet_samples)
         print(cnv_samples)
-        all_samples =set(samplesheet_samples).intersection(cnv_samples)
-        print(all_samples)
+        #all_samples =set(samplesheet_samples).intersection(cnv_samples)
+        #print(all_samples)
+        all_samples = cnv_samples
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples
 

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -192,7 +192,7 @@ def run_cnvreports(
         samplesheet_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
         # Find project to create jobs and outdirs in
         project_name = get_dx_cwd_project_name()
-        cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern=".vcf")
+        cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
         print(samplesheet_samples)
         print(cnv_samples)
         all_samples = samplesheet_samples - cnv_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -192,13 +192,13 @@ def run_cnvreports(
         samplesheet_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
         # Find project to create jobs and outdirs in
         project_name = get_dx_cwd_project_name()
+        # gather sample names that have a CNV VCF generated
         cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
         cnv_samples = [str(x) for x in cnv_samples]
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
-        #print(samplesheet_samples)
-        print(cnv_samples)
-        #all_samples =set(samplesheet_samples).intersection(cnv_samples)
-        #print(all_samples)
+        # Keep the samplesheet samples that have a CNV reports
+        all_samples =set(samplesheet_samples).intersection(cnv_samples)
+        print(all_samples)
         all_samples = cnv_samples
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -193,6 +193,7 @@ def run_cnvreports(
         # Find project to create jobs and outdirs in
         project_name = get_dx_cwd_project_name()
         cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
+        cnv_samples = [x.split('-')[0] for x in cnv_samples]
         print(samplesheet_samples)
         print(cnv_samples)
         all_samples = samplesheet_samples - cnv_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -192,8 +192,8 @@ def run_cnvreports(
         samplesheet_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
         # Find project to create jobs and outdirs in
         project_name = get_dx_cwd_project_name()
-        cnv_samples = set(find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'"))
-        cnv_samples = [x.split('-')[0] for x in cnv_samples]
+        cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
+        cnv_samples = set([x.split('-')[0] for x in cnv_samples])
         print(samplesheet_samples)
         print(cnv_samples)
         all_samples = samplesheet_samples - cnv_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -193,6 +193,7 @@ def run_cnvreports(
         # Find project to create jobs and outdirs in
         project_name = get_dx_cwd_project_name()
         cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
+        cnv_samples = [str(x) for x in cnv_samples]
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
         print(samplesheet_samples)
         print(cnv_samples)

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -192,7 +192,7 @@ def run_cnvreports(
         samplesheet_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
         # Find project to create jobs and outdirs in
         project_name = get_dx_cwd_project_name()
-        cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
+        cnv_samples = set(find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'"))
         cnv_samples = [x.split('-')[0] for x in cnv_samples]
         print(samplesheet_samples)
         print(cnv_samples)

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -16,7 +16,9 @@ from general_functions import (
     parse_genepanels,
     get_sample_ids_from_sample_sheet,
     gather_sample_sheet,
-    get_stage_inputs
+    get_stage_inputs,
+    find_files,
+    get_dx_cwd_project_name
 )
 
 def create_job_reports(rpt_out_dir, all_samples, job_dict):
@@ -187,7 +189,13 @@ def run_cnvreports(
         sample_id_list = reanalysis_dict
     else:
         sample_sheet_path = gather_sample_sheet()
-        all_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
+        samplesheet_samples = get_sample_ids_from_sample_sheet(sample_sheet_path)
+        # Find project to create jobs and outdirs in
+        project_name = get_dx_cwd_project_name()
+        cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern=".vcf")
+        print(samplesheet_samples)
+        print(cnv_samples)
+        all_samples = samplesheet_samples - cnv_samples
         print(all_samples)
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples

--- a/cnvreports.py
+++ b/cnvreports.py
@@ -196,8 +196,8 @@ def run_cnvreports(
         cnv_samples = find_files(project_name, ss_workflow_out_dir+cnv_calling_dir, pattern="-E '(.*).vcf$'")
         cnv_samples = [str(x) for x in cnv_samples]
         cnv_samples = set([x.split('-')[0] for x in cnv_samples])
-        # Keep the samplesheet samples that have a CNV reports
-        all_samples =set(samplesheet_samples).intersection(cnv_samples)
+        # Keep the samplesheet samples that have a CNV report
+        all_samples = set(samplesheet_samples).intersection(cnv_samples)
         stage_input_dict = assay_config.cnv_rpt_stage_input_dict
         sample_id_list = all_samples
 


### PR DESCRIPTION
Keeps the sample list (derived from the samplesheet) where CNV VCFs were generated from the cnvcalling app. This overrides the bug where if a sample has no CNV VCF, dias batch does not say that the inputs for a sample is not found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/90)
<!-- Reviewable:end -->
