### PR TITLE
DI-225 adjustment to CNVcalling due to automation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,10 +1,21 @@
 # dias.py
 
-This readme is mainly to help understand what's going on. To understand how to run it, get trained by a qualified member of the team or read the Dias manual in Q-Pulse
+This Python module was developed by the East GLH bioinformatics team to run DNAnexus workflows as part of germline analysis of next generation sequencing data: from FASTQ to Excel variant workbooks, generating quality and coverage reports.
+This READme describes the module architecture and should serve as a guide to future users and developers of the Dias pipeline.
+To understand how to run it, get trained by a qualified member of the team and read the Dias manual.
 
 ## Function
 
-Run the Dias pipeline stored in DNAnexus
+Run components of the Dias pipeline stored in DNAnexus as apps or workflows. This module collects the aproppriate input files for each stage in the workflows, sets off the jobs on DNAnexus and direct the output files into folders in a predefined structure.
+
+
+It curently supports the following workflows and apps:
+* dias_single_workflow: ran once per sample on a sequencing run
+* dias_multi_workflow: ran once per sequencing run
+* qc: the MultiQC app is ran once per sequencing run
+* cnvcall: GATK's germline CNV calling steps are ran in cohort mode (ran once per sequencing run)
+* dias_reports_workflow: ran once per sample
+* dias_cnvreports_workflow: ran once per sample
 
 ## Files
 
@@ -17,10 +28,10 @@ Run the Dias pipeline stored in DNAnexus
 - multi_workflow.py
   - Generates the batch tsv and runs the dx cmd to start the multi workflow
 - multiqc.py
-  - Runs the multiqc
+  - Runs the MultiQC app to generate a run-level quality report
 - cnvcalling.py
-  - Generate batch files for CNVcalling
+  - Runs the GATK_gCNV app for run-level CNVcalling, with samples listed in the input file excluded
 - reports.py
-  - Generate batch files for reports and reanalysis
+  - Generate batch files for reports workflow and reanalysis requests
 - cnvreports.py
-  - Generate batch files for CNV reports and CNV reanalysis
+  - Generate batch files for CNV reports workflow and CNV reanalysis requests

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -32,14 +32,8 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
     project_name = get_dx_cwd_project_name()
 
     # Make sure path provided is an actual ss workflow output folder
-    assert ss_workflow_out_dir.startswith("/"), (
-        "Input directory must be full path (starting at /)")
-    path_dirs = [x for x in ss_workflow_out_dir.split("/") if x]
-    is_path_single = [ele for ele in path_dirs if "single" in ele]
-    assert is_path_single != [], (
-        "Path '{}' is not an accepted directory, "
-        "must contain 'single'".format(ss_workflow_out_dir)
-    )
+    assert ss_workflow_out_dir.startswith("/output/"), (
+        "Input directory must be full path (starting with /output/)")
 
     # Find the app name and create an output folder for it under ss
     app_name = get_object_attribute_from_object_id_or_path(

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -1,9 +1,5 @@
 #!/usr/bin/python
-from ast import excepthandler
-import sys
 import subprocess
-import dxpy
-import re
 
 from general_functions import (
     get_dx_cwd_project_name,
@@ -39,8 +35,6 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
     app_name = get_object_attribute_from_object_id_or_path(
         assay_config.cnvcall_app_id, "Name"
     )
-
-
     app_output_dir = make_app_output_dir(assay_config.cnvcall_app_id, ss_workflow_out_dir, app_name, assay_id)
 
     # Find bam and bai files from sentieon folder

--- a/cnvcalling.py
+++ b/cnvcalling.py
@@ -91,14 +91,20 @@ def run_cnvcall_app(ss_workflow_out_dir, dry_run, assay_config, assay_id, exclud
         file_ids,
         project_name, app_output_dir
     )
+
     # upload excluded regions file
     excluded_list_path = app_output_dir + "/" + "excluded_list.tsv"
     cmd = "dx upload {} --path {}".format(excluded_sample_list, excluded_list_path)
-    subprocess.check_output(cmd, shell=True)
 
     if dry_run is True:
+        print("Created output dir: {}".format(app_output_dir))
         print("Final cmd ran: {}".format(command))
+        print("Deleting '{}' as part of the dry-run".format(app_output_dir))
+        delete_folders_cmd = "dx rm -r {}".format(app_output_dir)
+        subprocess.call(delete_folders_cmd, shell=True)
+
     else:
         subprocess.call(command, shell=True)
+        subprocess.check_output(cmd, shell=True)
 
     return app_output_dir

--- a/dias.py
+++ b/dias.py
@@ -215,6 +215,7 @@ def main():
     # Set off relevant workflow based on subcommand
     # with applicable inputs
     if subcommand == "cnvcall":
+        assert args.sample_list, "Please specify a sample exclusion list, including at least the control sample"
         cnvcall_applet_out_dir = run_cnvcall_app(
             args.input_dir, args.dry_run, config, assay_id,
             args.sample_list


### PR DESCRIPTION
## Summary
The output directory structure has changed since eggd_conductor is used to automatically set off dias_single, dias_multi and MultiQC. 

### Details
* In the `cnvcalling.py` script there were hard coded requirements for the input path to include the string "single" as this is what used to be the name of the dias_single workflow's output directory, which has now changed to be the assay name and datetime stamp only (eg `CEN-230407_2148`). This assertion has now been removed. [0f2a1f8](https://github.com/eastgenomics/dias_batch_running/commit/0f2a1f86f4c67cff0643827f860cc4b5e04f62bc)
* Also in the `cnvcalling.py` script, "EGG" codes were required to be in the sample name from the exclusion.txt input to the script. This will no longer be available with Epic sample naming, therefore the logic of collecting  and excluding input bam/bai files has been updated. [6374886](https://github.com/eastgenomics/dias_batch_running/commit/63748864dcde0376f6ca4617d46927871f6fc254)
* Lastly, in the `dias.py` script an assertion was added to ensure an exclusion list file is always provided for CNVcalling

closes #84, resolves #94

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/95)
<!-- Reviewable:end -->
