### PR TITLE
minor fixes for v2.0.1

### DIFF
--- a/cnvreports.py
+++ b/cnvreports.py
@@ -211,8 +211,9 @@ def run_cnvreports(
                     panels.append(CI)
                 else:
                     clinical_indication = next(
-                        (key for key in CI2panels_dict.keys() if key == CI),
-                        None)
+                        (key for key in CI2panels_dict.keys()
+                            if key.split("_")[0] == CI.split("_")[0]), None
+                        )
                     if clinical_indication is None:
                         # skip sample if CI not found
                         skip_sample = True

--- a/general_functions.py
+++ b/general_functions.py
@@ -750,15 +750,20 @@ def parse_Gemini_manifest(manifest_file): # reports
             )
             sample_identifier = record[0] # X number
             clinical_indications = record[-1].split(",")
-            CIs = list(set(
-                [CI for CI in clinical_indications if CI.startswith("R") or CI.startswith("_")]
+            # expecting Test Codes to be comma-separated
+            # handle R###.# and C##.# test codes and _HGNC IDs
+            # strip whitespaces in case they get through somehow
+            test_codes = list(set(
+                [CI.strip(" ") for CI in clinical_indications if
+                re.search(r"^[RC][0-9]+\.[0-9]+", CI.strip(" ")) or
+                re.search(r"^_HGNC", CI.strip(" "))]
             ))
-            # if sample is already assigned to a list of CIs, extend the list
+            # if sample is already assigned to a list of test_codes, extend the list
             if sample_identifier in data.keys():
-                data[sample_identifier]["CIs"].append(CIs)
-            # if sample has no CIs yet, save the list
+                data[sample_identifier]["test_codes"].extend(test_codes)
+            # if sample has no test_codes yet, save the list
             else:
-                data[sample_identifier] = {"test_codes": CIs}
+                data[sample_identifier] = {"test_codes": test_codes}
 
     return data
 

--- a/general_functions.py
+++ b/general_functions.py
@@ -903,7 +903,7 @@ def create_job_report_file(job__report_dict):
         )
         for sample, test in job__report_dict["invalid_tests"]:
             f.write(
-                "  * {}: {}".format(sample, test)
+                "{}\t{}\n".format(sample, test)
             )
 
     return job_report_file

--- a/reports.py
+++ b/reports.py
@@ -210,8 +210,9 @@ def run_reports(
                     panels.append(CI)
                 else:
                     clinical_indication = next(
-                        (key for key in CI2panels_dict.keys() if key == CI),
-                        None)
+                        (key for key in CI2panels_dict.keys()
+                            if key.split("_")[0] == CI.split("_")[0]), None
+                        )
                     if clinical_indication is None:
                         # skip sample if CI not found
                         skip_sample = True


### PR DESCRIPTION
`parse_Gemini_manifest`:
* restrict parsing of clinical indications that start with an `R` code, `C` code or `_HGNC` ID
* correctly identify ALL test codes for a sample that may be across multiple lines within the reanalysis file

in the `reports.py` and `cnvreports.py`:
* match only on the R code part of the clinical indication from a Gemini file to genepanels

`create_job_report_file`:
* present list of samples and invalid test codes as one pair per line for easier copy-pasting to repeat analysis job with corrected test codes

For further information see [DI-286](https://cuhbioinformatics.atlassian.net/browse/DI-286)