### PR TITLE
Unit tests for dx_requests.py

### DIFF
--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -181,11 +181,16 @@ def main(
 
     dxpy.set_workspace_id(os.environ.get('DX_PROJECT_CONTEXT_ID'))
 
-    assay_config = DXManage().get_assay_config(
-        path=assay_config_dir,
-        file=assay_config_file,
-        assay=assay
-    )
+    if assay_config_file:
+        assay_config = DXManage().read_assay_config_file(
+            file=assay_config_file
+        )
+
+    if assay and assay_config_dir:
+        assay_config = DXManage().get_assay_config(
+            assay=assay,
+            path=assay_config_dir
+        )
 
     assay_config = fill_config_reference_inputs(assay_config)
 

--- a/resources/home/dnanexus/dias_batch/tests/pytest.ini
+++ b/resources/home/dnanexus/dias_batch/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*U.*DeprecationWarning

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -6,10 +6,11 @@ launching jobs (in DXExecute).
 Functions not covered by unit tests:
     - DXManage.read_assay_config() - mostly just calls DXFile.read() on
         provided dx file ID
-    - DXManage().read_dxfile() - just reads file object from given dx
+    - DXManage().read_dxfile() - reads file object from given dx
         file ID, not expected to raise any errors
     - Everything in DXExecute - all functions relate to launching jobs,
-        going to test these manually in by running the app
+        going to test these manually by running the app (probably, we shall
+        see if I get the motivation to try patch things well to test them)
 """
 from copy import deepcopy
 import json

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1,11 +1,15 @@
 """
-Limited test suite for dx_requests.py
-
 The majority of functions in dx_requests.py relate to interacting with
 DNAnexus via dxpy API calls to either manage data (in DXManage) or for
-launching jobs (in DXExecute), therefore a lot of this is a pain to write
-unit tests for. The majority of the logic of parsing the output of functions
-in DXManage is in utils.py with its own unit tests.
+launching jobs (in DXExecute).
+
+Functions not covered by unit tests:
+    - DXManage.read_assay_config() - mostly just calls DXFile.read() on
+        provided dx file ID
+    - DXManage().read_dxfile() - just reads file object from given dx
+        file ID, not expected to raise any errors
+    - Everything in DXExecute - all functions relate to launching jobs,
+        going to test these manually in by running the app
 """
 from copy import deepcopy
 import json

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -152,8 +152,8 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
             {'assay': 'test', 'version': '1.0.0'},
             {'assay': 'test', 'version': '1.1.0'},
             {'assay': 'test', 'version': '1.0.10'},
-            {'assay': 'test', 'version': '2.0.0'},
-            {'assay': 'test', 'version': '1.1.11'}
+            {'assay': 'test', 'version': '1.1.11'},
+            {'assay': 'test', 'version': '1.2.1'}
         ]
 
         config = DXManage().get_assay_config(
@@ -161,7 +161,7 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
             assay='test'
         )
 
-        assert config['version'] == '2.0.0', (
+        assert config['version'] == '1.2.1', (
             "Incorrect config file version returned"            
         )
 

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1,0 +1,210 @@
+"""
+Limited test suite for dx_requests.py
+
+The majority of functions in dx_requests.py relate to interacting with
+DNAnexus via dxpy API calls to either manage data (in DXManage) or for
+launching jobs (in DXExecute), therefore a lot of this is a pain to write
+unit tests for. The majority of the logic of parsing the output of functions
+in DXManage is in utils.py with its own unit tests.
+"""
+from copy import deepcopy
+import json
+import os
+import pytest
+import re
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+import dxpy
+import pandas as pd
+
+
+sys.path.append(os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '../../')
+))
+
+from utils.dx_requests import DXManage
+
+
+TEST_DATA_DIR = (
+    os.path.join(os.path.dirname(__file__), 'test_data')
+)
+
+
+class TestDXManageGetAssayConfig(unittest.TestCase):
+    """
+    Tests for DXManage.get_assay_config()
+
+    Function either takes a path and assay string to search in DNAnexus
+    and return the highest config file version for
+    """
+    def test_error_raised_when_path_invalid(self):
+        """
+        AssertionError should be raised if path param is not valid
+        """
+        expected_error = 'path to assay configs appears invalid: invalid_path'
+
+        with pytest.raises(AssertionError, match=expected_error):
+            DXManage().get_assay_config(path='invalid_path', assay='')
+
+
+    @patch('utils.dx_requests.dxpy.find_data_objects')
+    def test_error_raised_when_no_config_files_found(self, test_patch):
+        """
+        AssertionError should be raised if no JSON files found, patch
+        the return of the dxpy.find_data_objects() call to be empty and
+        check we raise an error correctly
+        """
+        test_patch.return_value = []
+
+        expected_error = (
+            'No config files found in given path: project-xxx:/test_path'
+        )
+        with pytest.raises(AssertionError, match=expected_error):
+            DXManage().get_assay_config(path='project-xxx:/test_path', assay='')
+
+
+    @patch('utils.dx_requests.json.loads')
+    @patch('utils.dx_requests.dxpy.bindings.dxfile.DXFile')
+    @patch('utils.dx_requests.dxpy.find_data_objects')
+    def test_error_raised_when_no_config_file_found_for_assay(
+            self,
+            mock_find,
+            mock_file,
+            mock_read
+        ):
+        """
+        AssertionError should be raised if we find some JSON files but
+        after parsing through none of them match our given assay string
+        against the 'assay' key in the config
+        """
+        # set output of find to be minimal describe call output with
+        # required keys for iterating over
+        mock_find.return_value = [
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx',
+                'describe' : {
+                    'name': 'config1.json',
+                    'archivalState': 'live'
+                }
+            }
+        ]
+
+        # patch the DXFile object that read() gets called on
+        mock_file.return_value = dxpy.bindings.dxfile.DXFile
+
+        # patch the output from DXFile.read() to just be all the same dict
+        mock_read.return_value = {'assay': 'CEN', 'version': '1.0.0'}
+
+        expected_error = (
+            "No config file was found for test from project-xxx:/test_path"
+        )
+
+        with pytest.raises(AssertionError, match=expected_error):
+            DXManage().get_assay_config(
+                path='project-xxx:/test_path',
+                assay='test'
+            )
+
+
+    @patch('utils.dx_requests.json.loads')
+    @patch('utils.dx_requests.dxpy.bindings.dxfile.DXFile')
+    @patch('utils.dx_requests.dxpy.find_data_objects')
+    def test_highest_version_correctly_selected(
+            self,
+            mock_find,
+            mock_file,
+            mock_read
+        ):
+        """
+        Test that when multiple configs are found for an assay, the
+        highest version is correctly returned. We're using
+        packaging.version.Version to compare versions parsed from
+        the config files so this _should_ work as we expect
+        """
+        # set output of find to be minimal describe call output with
+        # required keys for iterating over, here we need a dict per
+        # `mock_read` return values that we want to test with
+        mock_find.return_value = [
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx',
+                'describe' : {
+                    'name': 'config.json',
+                    'archivalState': 'live'
+                }
+            }
+        ] * 5
+
+        # patch the DXFile object that read() gets called on
+        mock_file.return_value = dxpy.bindings.dxfile.DXFile
+
+        # patch the output from DXFile.read() to simulate looping over
+        # the return of reading multiple configs
+        mock_read.side_effect = [
+            {'assay': 'test', 'version': '1.0.0'},
+            {'assay': 'test', 'version': '1.1.0'},
+            {'assay': 'test', 'version': '1.0.10'},
+            {'assay': 'test', 'version': '2.0.0'},
+            {'assay': 'test', 'version': '1.1.11'}
+        ]
+
+        config = DXManage().get_assay_config(
+            path='project-xxx:/test_path',
+            assay='test'
+        )
+
+        assert config['version'] == '2.0.0', (
+            "Incorrect config file version returned"            
+        )
+
+
+class TestDXManageGetFileProjectContext(unittest.TestCase):
+    """
+    Tests for DXManage.get_file_project_context()
+
+    Function takes a DXFile ID and returns a project ID in which
+    the file has been found in a live state
+    """
+
+    @patch('utils.dx_requests.dxpy.DXFile.describe')
+    @patch('utils.dx_requests.dxpy.DXFile')
+    @patch('utils.dx_requests.dxpy.find_data_objects')
+    def test_no_live_files(
+            self,
+            mock_find,
+            mock_file,
+            mock_describe
+        ):
+        """
+        Test that when no files in a live state are found that an
+        AssertionError is raised
+        """
+        # patch the DXFile object to nothing as we won't use it,
+        # and the output of dx find to be a minimal set of describe calls
+        # mock_file.return_value = dxpy.DXFile(dxid='file-xxx')
+        mock_describe.return_value = {}
+        mock_find.return_value = [
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx',
+                'describe' : {
+                    'archivalState': 'archived'
+                }
+            },
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx',
+                'describe' : {
+                    'archivalState': 'archival'
+                }
+            }
+        ]
+
+        correct_error = 'No live files could be found for the ID: file-xxx'
+
+        with pytest.raises(AssertionError, match=correct_error):
+            DXManage().get_file_project_context(file='file-xxx')

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import concurrent.futures
 import json
 import os
+from packaging.version import Version, parse
 import re
 from timeit import default_timer as timer
 from typing import Tuple
@@ -25,17 +26,50 @@ class DXManage():
     """
     Methods for generic handling of dx related things
     """
-
-    def get_assay_config(self, path, file, assay) -> dict:
+    def read_assay_config_file(self, file):
         """
-        Get highest config file from given path for given assay
+        Read assay config file specified with -iassay_config_file
+
+        Parameters
+        ----------
+        file : str
+            DNAnexus file ID of config to read
+        """
+        print("Reading in specified assay config file...")
+        file = file.get('$dnanexus_link')
+
+        if not file.startswith('project'):
+            # just file-xxx provided => find a project the file is in
+            file_details = self.get_file_project_context(file)
+        else:
+            project, file_id = file.split(':')
+            file_details = dxpy.bindings.dxfile.DXFile(
+                project=project, dxid=file_id).describe()
+        print(
+            f"Using assay config file: {file_details['describe']['name']} "
+            f"({file_details['project']}:{file_details['id']})"
+        )
+
+        config = json.loads(dxpy.bindings.dxfile.DXFile(
+            project=file_details['project'], dxid=file_details['id']).read())
+
+        config['name'] = file_details['describe']['name']
+        config['dxid'] = file_details['id']
+
+        print("Assay config file contents:")
+        prettier_print(config)
+        return config
+
+
+    def get_assay_config(self, path, assay) -> dict:
+        """
+        Get highest config file from given path for given assay and
+        read in to a dict
 
         Parameters
         ----------
         path : str
             DNAnexus project:path to dir containing assay configs
-        file: str
-            DNAnexus file ID of config file to use instead of searching
         assay : str
             assay string to return configs for (i.e. CEN or WES)
 
@@ -43,34 +77,16 @@ class DXManage():
         -------
         dict
             contents of config file
+        
+        Raises
+        ------
+        AssertionError
+            Raised if 'path' parameter not a valid project-xxx:/ path
+        AssertionError
+            Raised if no config files found at the given path
+        AssertionError
+            Raised if no config files found for the given assay string
         """
-        if file:
-            # specified file to use => read in and return
-            print("Reading in specified assay config file")
-            file = file.get('$dnanexus_link')
-
-            if not file.startswith('project'):
-                # just file-xxx provided => find a project the file is in
-                file_details = self.get_file_project_context(file)
-            else:
-                project, file_id = file.split(':')
-                file_details = dxpy.bindings.dxfile.DXFile(
-                    project=project, dxid=file_id).describe()
-            print(
-                f"Using assay config file: {file_details['describe']['name']} "
-                f"({file_details['project']}:{file_details['id']})"
-            )
-
-            config = json.loads(dxpy.bindings.dxfile.DXFile(
-                project=file_details['project'], dxid=file_details['id']).read())
-
-            config['name'] = file_details['describe']['name']
-            config['dxid'] = file_details['id']
-
-            print("Assay config file contents:")
-            prettier_print(config)
-            return config
-
         # searching dir for configs, check for valid project:path structure
         assert re.match(r'project-[\d\w]*:/.*', path), (
             f'path to assay configs appears invalid: {path}'
@@ -80,6 +96,8 @@ class DXManage():
 
         project, project_path = path.split(':')
 
+        print('here1')
+
         files = list(dxpy.find_data_objects(
             name=".json$",
             name_mode='regexp',
@@ -87,6 +105,8 @@ class DXManage():
             folder=project_path,
             describe=True
         ))
+
+        print('here2')
 
         # sense check we find config files
         assert files, f"No config files found in given path: {path}"
@@ -113,10 +133,14 @@ class DXManage():
             if not config_data.get('assay') == assay:
                 continue
 
-            if config_data.get('version') > highest_config.get('version'):
+            if Version(config_data.get('version')) > Version(highest_config.get('version', '0')):
                 config_data['dxid'] = file['id']
                 config_data['name'] = file['describe']['name']
                 highest_config = config_data
+
+        assert highest_config, (
+            f"No config file was found for {assay} from {path}"
+        )
 
         print(
             f"Highest version config found for {assay} was "

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -96,8 +96,6 @@ class DXManage():
 
         project, project_path = path.split(':')
 
-        print('here1')
-
         files = list(dxpy.find_data_objects(
             name=".json$",
             name_mode='regexp',
@@ -105,8 +103,6 @@ class DXManage():
             folder=project_path,
             describe=True
         ))
-
-        print('here2')
 
         # sense check we find config files
         assert files, f"No config files found in given path: {path}"


### PR DESCRIPTION
## Summary

Unit tests for functions in `utils.dx_requests.py`, these are mostly for functions managing and findings files in DNAnexus under `DXManage()`

## Changes
- separate out reading of assay config file provided to `-iassay_config_file()` to its own function (`DXManage.read_assay_config_file()`) from searching in DNAnexus for one
- Fix correctly getting highest version config file by using `packaging.version.Version`
- unit tests added to `test_dx_requests.py`

```
jethro@jethro-T490:~/Projects/dias_batch_running$ python3 -m pytest -v resources/home/dnanexus/dias_batch/tests/
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch/tests, configfile: pytest.ini
plugins: Faker-14.0.0, mock-3.9.0, cov-4.0.0
collected 9 items                                                                                                                                                                                                                       

resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_no_config_file_found_for_assay PASSED                                                                            [ 11%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_no_config_files_found PASSED                                                                                     [ 22%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_path_invalid PASSED                                                                                              [ 33%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_highest_version_correctly_selected PASSED                                                                                          [ 44%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetFileProjectContext::test_no_live_files PASSED                                                                                                        [ 55%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_files_just_path_returned PASSED                                                                                                         [ 66%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_sub_dir_filters_correctly PASSED                                                                                                        [ 77%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFormatOutputFolders::test_correct_folder_app PASSED                                                                                                     [ 88%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFormatOutputFolders::test_correct_folder_applet PASSED                                                                                                  [100%]

=========================================================================================================== 9 passed in 0.53s ===========================================================================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/121)
<!-- Reviewable:end -->
