### PR TITLE
Unit tests for CheckInputs

### DIFF
--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -346,4 +346,6 @@ def main(
         "launched_jobs": launched_jobs
     }
 
-dxpy.run()
+if os.path.exists('/home/dnanexus'):
+    # check for env to allow importing CheckInputs for unit tests
+    dxpy.run()

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -120,10 +120,10 @@ class CheckInputs():
                     self.inputs['single_output_dir'] = prefix_path
                     return
 
-            self.errors.append(
-                "Given Dias single output dir appears to be empty: "
-                f"{self.inputs['single_output_dir']}"
-            )
+        self.errors.append(
+            "Given Dias single output dir appears to be empty: "
+            f"{self.inputs['single_output_dir']}"
+        )
 
     def check_mode_set(self):
         """Check at least one running mode set and manifest passed if running reports"""
@@ -131,9 +131,9 @@ class CheckInputs():
         if not any(self.inputs.get(x) for x in modes):
             self.errors.append('No mode specified to run in')
 
-        report_modes = modes.pop(0)
+        modes.pop(0)
         if any([
-            self.inputs.get(x) for x in report_modes
+            self.inputs.get(x) for x in modes
         ]) and not self.inputs.get('manifest_file'):
             self.errors.append(
                 'Reports argument specified with no manifest file'

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -1,18 +1,9 @@
 """
 Tests for CheckInputs() that are run at the beginning of dias batch
 """
-from copy import deepcopy
-import json
 import os
-import pytest
-import re
-import subprocess
 import sys
-import unittest
 from unittest.mock import patch
-
-import dxpy
-import pandas as pd
 
 
 sys.path.append(os.path.abspath(

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -77,4 +77,91 @@ class TestCheckInputs():
             'Correct error not raised for empty assay config dir'
         )
 
-    def test_check_single_output_dir()
+    @patch('utils.dx_requests.dxpy.find_data_objects')
+    def test_check_single_output_dir(self, test_patch, mocker):
+        """
+        Test when no files are found in single output dir error is raised
+        """
+        test_patch.return_value = []
+
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+        check.inputs = {
+            'single_output_dir': 'project-xxx:/some_empty_path'
+        }
+
+        check.check_single_output_dir()
+
+        correct_error = [
+            'Given Dias single output dir appears to be empty: '
+            'project-xxx:/some_empty_path'
+        ]
+
+        assert check.errors == correct_error, (
+            'Error not raised for empty single directory'
+        )
+
+    def test_check_no_mode_set(self, mocker):
+        """
+        Check correct error raised if no mode set
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+        check.inputs = {}
+
+        check.check_mode_set()
+
+        assert check.errors == ['No mode specified to run in'], (
+            'Error not raised for no running mode set'
+        )
+
+    def test_error_raised_for_no_manifest_with_reports_mode(self, mocker):
+        """
+        Test error is raised when a reports mode is set and no manifest given
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+
+        for mode in [
+            'cnv_call', 'cnv_reports', 'snv_reports', 'mosaic_reports'
+        ]:
+            check.inputs = {
+                mode: True
+            }
+
+            check.check_mode_set()
+
+        correct_error = ['Reports argument specified with no manifest file'] * 3
+
+        assert check.errors == correct_error, (
+            'Error not raised for reports mode and missing manifest'
+        )
+
+    def test_error_raised_for_cnv_reports_invalid(self, mocker):
+        """
+        Test when CNV reports is to be run that errors is raised if
+        CNV call mode or CNV call job ID is missing
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+        check.inputs = {'cnv_reports': True}
+
+        check.check_cnv_calling_for_cnv_reports()
+
+        correct_error = [
+            "Running CNV reports without first running CNV calling and "
+            "cnv_call_job_ID not specified. Please rerun with "
+            "'-icnv_call=true or specify a job ID with '-icnv_call_job_id'"
+        ]
+
+        assert check.errors == correct_error, (
+            "Error not raised for CNV reports missing CNV call / job ID"
+        )

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -46,7 +46,35 @@ class TestCheckInputs():
         }
 
         check.check_assay()
-        
+
         assert check.errors == ['Invalid assay passed: invalidAssay'], (
             'Error not raised for invalid assay string'
         )
+
+    @patch('utils.dx_requests.dxpy.find_data_objects')
+    def test_assay_config_dir(self, test_patch, mocker):
+        """
+        Test when assay config dir specified is empty that error is raised
+        """
+        test_patch.return_value = []
+
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+        check.inputs = {
+            'assay_config_dir': 'project-xxx:/some_empty_path'
+        }
+
+        check.check_assay_config_dir()
+
+        correct_error = [
+            'Given assay config dir appears to contain no config files: '
+            'project-xxx:/some_empty_path'
+        ]
+
+        assert check.errors == correct_error, (
+            'Correct error not raised for empty assay config dir'
+        )
+
+    def test_check_single_output_dir()

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -27,7 +27,7 @@ class TestCheckInputs():
     """
     def test_invalid_assay_str_error_raised(self, mocker):
         """
-        Test when an invalid assay string passed to -iassay error is raised
+        Test error is raised when an invalid assay string passed to -iassay
         """
         mocker.patch.object(CheckInputs, "__init__", return_value=None)
         check = CheckInputs()
@@ -45,7 +45,7 @@ class TestCheckInputs():
     @patch('utils.dx_requests.dxpy.find_data_objects')
     def test_assay_config_dir(self, test_patch, mocker):
         """
-        Test when assay config dir specified is empty that error is raised
+        Test that error is raised when assay config dir specified is empty
         """
         test_patch.return_value = []
 
@@ -71,7 +71,7 @@ class TestCheckInputs():
     @patch('utils.dx_requests.dxpy.find_data_objects')
     def test_check_single_output_dir(self, test_patch, mocker):
         """
-        Test when no files are found in single output dir error is raised
+        Test that error is raised when no files are found in single output dir
         """
         test_patch.return_value = []
 
@@ -136,7 +136,7 @@ class TestCheckInputs():
 
     def test_error_raised_for_cnv_reports_invalid(self, mocker):
         """
-        Test when CNV reports is to be run that errors is raised if
+        Test when CNV reports is to be run that an error is raised if
         CNV call mode or CNV call job ID is missing
         """
         mocker.patch.object(CheckInputs, "__init__", return_value=None)

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -1,0 +1,52 @@
+"""
+Tests for CheckInputs() that are run at the beginning of dias batch
+"""
+from copy import deepcopy
+import json
+import os
+import pytest
+import re
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+import dxpy
+import pandas as pd
+
+
+sys.path.append(os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '../../')
+))
+
+from ..dias_batch import CheckInputs
+
+
+TEST_DATA_DIR = (
+    os.path.join(os.path.dirname(__file__), 'test_data')
+)
+
+class TestCheckInputs():
+    """
+    Tests for each individual run time check performed on app inputs.
+
+    Each test will mimic setup performed in CheckInputs.__init__ with the
+    minimum inputs required set for that check, but not initialise the class
+    to stop it running all checks for every test
+    """
+    def test_invalid_assay_str_error_raised(self, mocker):
+        """
+        Test when an invalid assay string passed to -iassay error is raised
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        check = CheckInputs()
+        check.errors = []
+        check.inputs = {
+            'assay': 'invalidAssay'
+        }
+
+        check.check_assay()
+        
+        assert check.errors == ['Invalid assay passed: invalidAssay'], (
+            'Error not raised for invalid assay string'
+        )

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -526,10 +526,11 @@ class DXExecute():
         ]
 
         # patterns of sample ID and sample file prefix to match on
+        #TODO move these to config
         if manifest_source == 'Epic':
-            pattern = r'^[\d\w]+-[\d\w]+'
+            pattern = r'^[\d\w]+-[\d\w]+-'
         else:
-            pattern = r'X[\d]+'
+            pattern = r'X[\d]+-'
 
         # set up required files for each running mode
         if mode == 'CNV':
@@ -549,6 +550,7 @@ class DXExecute():
                 path=f"{job_details.get('project')}:{job_details.get('folder')}",
                 pattern="_excluded_intervals.bed$"
             ))
+            # TODO: check if file is always output (i.e. if its empty)
 
             if not excluded_intervals_bed:
                 raise RuntimeError(
@@ -566,6 +568,10 @@ class DXExecute():
                 }
             }
 
+            # TODO use exclude samples here to drop from manifest
+
+            # TODO I DONT THINK I NEED THIS AS WE DO THE SAME LATER ON SO I SHOULD PROBABLY LOOK AT IT LATER
+            
             # ensure we have vcf files per sample,
             # exclude those that don't have one
             manifest, manifest_no_match, manifest_no_vcf = \
@@ -641,8 +647,7 @@ class DXExecute():
         # gather errors to display in summary report
         errors = {}
 
-        # ensure we have a vcf and mosdepth files (for SNV)
-        # per sample, exclude those that don't have one
+        # ensure we have a vcf per sample, exclude those that don't have one
         manifest, manifest_no_match, manifest_no_vcf = \
             filter_manifest_samples_by_files(
                 manifest=manifest,
@@ -653,8 +658,8 @@ class DXExecute():
 
         if manifest_no_match:
             errors[
-                f"Samples in manifest not matching pattern "
-                f"({len(manifest_no_match)}) {pattern}:"
+                f"Samples in manifest not matching expected {manifest_source} "
+                f"pattern ({len(manifest_no_match)}) {pattern}:"
             ] = manifest_no_match
 
         if manifest_no_vcf:


### PR DESCRIPTION
## Summary

Unit tests for `CheckInputs` in dias_batch.py, these are all functions that run when the app starts to validate the inputs provided. This is likely to have more tests added as more checks are added once I think of everything needed for each mode, but its a start.

## Changes
- fix some bits of bugs in the checks highlighted by the tests
- added tests to `test_dias_batch.py`

```
jethro@jethro-T490:~/Projects/dias_batch_running$ python3 -m pytest -v resources/home/dnanexus/dias_batch/tests/
========================================================================================================== test session starts ==========================================================================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch/tests, configfile: pytest.ini
plugins: Faker-14.0.0, mock-3.9.0, cov-4.0.0
collected 6 items                                                                                                                                                                                                                       

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_invalid_assay_str_error_raised PASSED                                                                                                          [ 16%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_assay_config_dir PASSED                                                                                                                        [ 33%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_check_single_output_dir PASSED                                                                                                                 [ 50%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_check_no_mode_set PASSED                                                                                                                       [ 66%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_error_raised_for_no_manifest_with_reports_mode PASSED                                                                                          [ 83%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_error_raised_for_cnv_reports_invalid PASSED                                                                                                    [100%]

=========================================================================================================== 6 passed in 0.54s ===========================================================================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/122)
<!-- Reviewable:end -->
