### PR TITLE
More unit tests for utils

### DIFF
--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -251,8 +251,10 @@ def main(
     if manifest_file:
         # parse manifest and format into a mapping of sampleID -> test codes
         manifest_data = DXManage().read_dxfile(manifest_file)
-        manifest, manifest_source = parse_manifest(manifest_data)
-
+        manifest, manifest_source = parse_manifest(
+            contents=manifest_data,
+            split_tests=split_tests
+        )
 
         # filter manifest tests against genepanels to ensure what has been
         # requested are test codes or HGNC IDs we recognise

--- a/resources/home/dnanexus/dias_batch/tests/pytest.ini
+++ b/resources/home/dnanexus/dias_batch/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore:.*DeprecationWarning.*
+    ignore:.*U.*mode is deprecated:DeprecationWarning

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -552,8 +552,83 @@ class TestCheckManifestValidTestCodes():
 
 class TestSplitManifestTests():
     """
-    TODO
+    Tests for utils.split_manifest_tests()
+
+    Function parses through the list of lists of test codes for each sample
+    in the manifest and splits all test codes to be their own list, which
+    will result in them generating their own reports
     """
+
+    def test_panels_correctly_split_out(self):
+        """
+        Test that any panels are correctly split to their own test list
+        """
+        manifest = {
+            "sample1" : {'tests': [['R1.1', 'R134.1']]},
+            "sample2" : {'tests': [['R228.1']]},
+            "sample3" : {'tests': [['R218.2'], ['R2.1']]},
+        }
+
+        split_manifest = utils.split_manifest_tests(manifest)
+
+        correct_split = {
+            "sample1" : {'tests': [['R1.1'], ['R134.1']]},
+            "sample2" : {'tests': [['R228.1']]},
+            "sample3" : {'tests': [['R218.2'], ['R2.1']]},
+        }
+
+        assert split_manifest == correct_split, (
+            "Manifest test codes incorrectly split"
+        )
+
+    def test_gene_symbols_correctly_not_split(self):
+        """
+        Gene symbols requested together (i.e. in the same sub list of tests)
+        should _not_ be split, but those not requested together (i.e. in
+        different sub lists of tests) do _not_ get combined, test this works
+        """
+        manifest = {
+            "sample1" : {'tests': [['_HGNC:235']]},
+            "sample2" : {'tests': [['_HGNC:1623', '_HGNC:4401']]},
+            "sample3" : {'tests': [['_HGNC:152'], ['_HGNC:18']]}
+        }
+
+        split_manifest = utils.split_manifest_tests(manifest)
+
+        correct_split = manifest = {
+            "sample1" : {'tests': [['_HGNC:235']]},
+            "sample2" : {'tests': [['_HGNC:1623', '_HGNC:4401']]},
+            "sample3" : {'tests': [['_HGNC:152'], ['_HGNC:18']]}
+        }
+
+        assert split_manifest == correct_split, (
+            'Gene symbols incorrectly split'
+        )
+
+    def test_panels_and_gene_symbols_handled_together_correctly(self):
+        """
+        Combining the above to test mix of panels and gene symbols
+        are correctly split
+        """
+        manifest = {
+            "sample1" : {'tests': [['R1.1', 'R134.1', '_HGNC:235']]},
+            "sample2" : {'tests': [['R228.1']]},
+            "sample3" : {'tests': [['R218.2'], ['R2.1', '_HGNC:1623', '_HGNC:4401']]},
+            "sample4" : {'tests': [['R1.1', '_HGNC:152'], ['R1.2', '_HGNC:18']]}
+        }
+
+        split_tests = utils.split_manifest_tests(manifest)
+
+        correct_split = manifest = {
+            "sample1" : {'tests': [['R1.1'], ['R134.1'], ['_HGNC:235']]},
+            "sample2" : {'tests': [['R228.1']]},
+            "sample3" : {'tests': [['R218.2'], ['R2.1'], ['_HGNC:1623', '_HGNC:4401']]},
+            "sample4" : {'tests': [['R1.1'], ['_HGNC:152'], ['R1.2'], ['_HGNC:18']]}
+        }
+
+        assert split_tests == correct_split, (
+            'Mix of panels and gene symbols incorrectly split'
+        )
 
 
 class TestAddPanelsAndIndicationsToManifest():

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -608,12 +608,12 @@ class TestFilterManifestSamplesByFiles():
                 'Sample with no file not correctly added to '
                 'returned manifest_no_files list'
             )
-        
+
         if '123245111-23146R00111' in manifest.keys():
             errors.append(
                 'Sample with no file not correctly excluded from manifest'
             )
-        
+
         assert not errors, errors
 
 
@@ -893,14 +893,19 @@ class TestAddPanelsAndIndicationsToManifest():
                 "panels": [
                     ["Inherited ovarian cancer (without breast cancer)_4.0"]
                 ],
-                "indications": [
-                    ["R207.1_Inherited ovarian cancer (without breast cancer)_P"]
-                ]
+                "indications": [[
+                    "R207.1_Inherited ovarian cancer (without breast cancer)_P"
+                ]]
             },
             "224289111-33202R00111": {
                 "tests": [["R208.1"]],
                 "panels": [
-                    ["HGNC:1100_SG_panel_1.0.0;HGNC:1101_SG_panel_1.0.0;HGNC:16627_SG_panel_1.0.0;HGNC:26144_SG_panel_1.0.0;HGNC:795_SG_panel_1.0.0;HGNC:9820_SG_panel_1.0.0;HGNC:9823_SG_panel_1.0.0"]
+                    [
+                        "HGNC:1100_SG_panel_1.0.0;HGNC:1101_SG_panel_1.0.0;"
+                        "HGNC:16627_SG_panel_1.0.0;HGNC:26144_SG_panel_1.0.0;"
+                        "HGNC:795_SG_panel_1.0.0;HGNC:9820_SG_panel_1.0.0;"
+                        "HGNC:9823_SG_panel_1.0.0"
+                    ]
                 ],
                 "indications": [
                     ["R208.1_Inherited breast cancer and ovarian cancer_P"]
@@ -918,10 +923,19 @@ class TestAddPanelsAndIndicationsToManifest():
             "424487111-53214R00111": {
                 "tests": [["R208.1", "R216.1"]],
                 "panels": [
-                    ["HGNC:1100_SG_panel_1.0.0;HGNC:1101_SG_panel_1.0.0;HGNC:16627_SG_panel_1.0.0;HGNC:26144_SG_panel_1.0.0;HGNC:795_SG_panel_1.0.0;HGNC:9820_SG_panel_1.0.0;HGNC:9823_SG_panel_1.0.0", "HGNC:11998_SG_panel_1.0.0;HGNC:17284_SG_panel_1.0.0"]
+                    [
+                        "HGNC:1100_SG_panel_1.0.0;HGNC:1101_SG_panel_1.0.0;"
+                        "HGNC:16627_SG_panel_1.0.0;HGNC:26144_SG_panel_1.0.0;"
+                        "HGNC:795_SG_panel_1.0.0;HGNC:9820_SG_panel_1.0.0;"
+                        "HGNC:9823_SG_panel_1.0.0",
+                        "HGNC:11998_SG_panel_1.0.0;HGNC:17284_SG_panel_1.0.0"
+                    ]
                 ],
                 "indications": [
-                    ["R208.1_Inherited breast cancer and ovarian cancer_P", "R216.1_Li Fraumeni Syndrome_P"]
+                    [
+                        "R208.1_Inherited breast cancer and ovarian cancer_P",
+                        "R216.1_Li Fraumeni Syndrome_P"
+                    ]
                 ]
             },
             "X225111-GM2308111": {
@@ -934,7 +948,7 @@ class TestAddPanelsAndIndicationsToManifest():
                 ]
             }
         }
-        
+
         assert manifest == correct_manifest, (
             'Clinical indications and panels incorrectly added to manifest'
         )

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -791,7 +791,7 @@ def split_manifest_tests(data) -> dict:
                     test_genes.append(sub_test)
             if test_genes:
                 # there were some single genes to test
-                all_split_test_codes.append(list(set(test_genes)))
+                all_split_test_codes.append(sorted(set(test_genes)))
 
         split_data[sample]['tests'].extend(all_split_test_codes)
 

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -905,7 +905,7 @@ def add_panels_and_indications_to_manifest(manifest, genepanels) -> dict:
                     # we already validated earlier all the test codes so
                     # shouldn't get here
                     raise RuntimeError(
-                        f"Error occured selecting testing from genepanels for "
+                        "Error occured selecting test from genepanels for "
                         f"test {test}"
                     )
             sample_tests['panels'].append(panels)


### PR DESCRIPTION
## Changes
- unit tests added for `.filter_manifest_samples_by_files()`, `split_manifest_tests()` and `add_panel_and_indications_to_manifest()`
- fix to actually call `exclude_samples()` if specified
- minor change to sort the test lists to make testing work

```
jethro@jethro-T490:~/Projects/dias_batch_running$ python3 -m pytest -vvvv --cov resources/home/dnanexus/dias_batch/
====================================================== test session starts =======================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/dias_batch_running
plugins: Faker-14.0.0, mock-3.9.0, cov-4.0.0
collected 51 items                                                                                                               

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_invalid_assay_str_error_raised PASSED   [  1%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_assay_config_dir PASSED                 [  3%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_check_single_output_dir PASSED          [  5%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_check_no_mode_set PASSED                [  7%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_error_raised_for_no_manifest_with_reports_mode PASSED [  9%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_error_raised_for_cnv_reports_invalid PASSED [ 11%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_no_config_file_found_for_assay PASSED [ 13%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_no_config_files_found PASSED [ 15%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_path_invalid PASSED [ 17%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_highest_version_correctly_selected PASSED [ 19%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetFileProjectContext::test_no_live_files PASSED [ 21%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_files_just_path_returned PASSED  [ 23%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_sub_dir_filters_correctly PASSED [ 25%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFormatOutputFolders::test_correct_folder_app PASSED [ 27%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFormatOutputFolders::test_correct_folder_applet PASSED [ 29%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_max_suffix_snv PASSED                   [ 31%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_max_suffix_cnv PASSED                   [ 33%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_suffix_1_returned_no_previous_reports PASSED [ 35%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_prev_samples_but_no_suffix_in_name PASSED [ 37%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestMakePath::test_path_mix PASSED                                 [ 39%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_all_reference_files_added PASSED [ 41%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_reference_added_as_just_file_id PASSED [ 43%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_reference_added_as_dx_link_mapping PASSED [ 45%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_malformed_reference PASSED     [ 47%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseGenePanels::test_correct_indications PASSED               [ 49%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseGenePanels::test_correct_panels PASSED                    [ 50%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_genepanels_unchanged_by_splitting PASSED [ 52%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_splitting_r_code PASSED         [ 54%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_splitting_c_code PASSED         [ 56%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_catch_multiple_indication_for_one_test_code PASSED [ 58%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_gemini_not_two_columns PASSED              [ 60%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_gemini_multiple_lines_combined PASSED      [ 62%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_correct_number_lines_parsed PASSED    [ 64%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_required_columns_checked PASSED       [ 66%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_spaces_and_sp_prefix_removed PASSED   [ 68%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_reanalysis_ids_used PASSED            [ 70%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_missing_sample_id_caught PASSED       [ 72%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_invalid_manifest PASSED                    [ 74%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_files_not_matching_pattern_filtered_out PASSED [ 76%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_samples_not_matching_pattern_filtered_out PASSED [ 78%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_sample_in_manifest_has_no_files PASSED [ 80%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_files_correctly_added_to_manifest PASSED [ 82%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_not_raised_on_valid_codes PASSED [ 84%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_raised_when_sample_has_no_tests PASSED [ 86%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_raised_when_manifest_contains_invalid_test_code PASSED [ 88%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_not_raised_when_research_use_test_code_present PASSED [ 90%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitManifestTests::test_panels_correctly_split_out PASSED     [ 92%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitManifestTests::test_gene_symbols_correctly_not_split PASSED [ 94%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitManifestTests::test_panels_and_gene_symbols_handled_together_correctly PASSED [ 96%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestAddPanelsAndIndicationsToManifest::test_invalid_test_code_caught PASSED [ 98%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestAddPanelsAndIndicationsToManifest::test_correct_indications_panels PASSED [100%]

---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                                           Stmts   Miss  Cover
----------------------------------------------------------------------------------
resources/home/dnanexus/dias_batch/__init__.py                     0      0   100%
resources/home/dnanexus/dias_batch/dias_batch.py                 141     91    35%
resources/home/dnanexus/dias_batch/tests/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py       63      0   100%
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py      78      0   100%
resources/home/dnanexus/dias_batch/tests/test_utils.py           232      4    98%
resources/home/dnanexus/dias_batch/utils/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/utils/dx_requests.py          316    231    27%
resources/home/dnanexus/dias_batch/utils/utils.py                268     51    81%
----------------------------------------------------------------------------------
TOTAL                                                           1098    377    66%


======================================================= 51 passed in 2.01s =======================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/125)
<!-- Reviewable:end -->
