### PR TITLE
Lots more unit tests and some bug fixes

### DIFF
--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -415,7 +415,7 @@ def main(
     summary_file = f"{project_name}_{start_time}_job_summary.txt"
 
     job_details = dxpy.DXJob(dxid=os.environ.get('DX_JOB_ID')).describe()
-    app_details = dxpy.DXApp(dxid=job['executable']).describe()
+    app_details = dxpy.DXApp(dxid=job_details['executable']).describe()
 
     write_summary_report(
         summary_file,

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -417,6 +417,11 @@ def main(
     job_details = dxpy.DXJob(dxid=os.environ.get('DX_JOB_ID')).describe()
     app_details = dxpy.DXApp(dxid=job_details['executable']).describe()
 
+    # overwrite manifest job ID in job details with name to write to summary
+    job_details['runInput']['manifest_file'] = dxpy.describe(
+        job_details['runInput']['manifest_file']['$dnanexus_link']
+    )['name']
+
     write_summary_report(
         summary_file,
         job=job_details,

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -309,6 +309,7 @@ def main(
                 config=assay_config,
                 single_output_dir=single_output_dir,
                 exclude=exclude_samples,
+                start=start_time,
                 wait=wait,
                 unarchive=unarchive
             )

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -414,8 +414,13 @@ def main(
     project_name = dxpy.describe(os.environ.get('DX_PROJECT_CONTEXT_ID'))['name']
     summary_file = f"{project_name}_{start_time}_job_summary.txt"
 
+    job_details = dxpy.DXJob(dxid=os.environ.get('DX_JOB_ID')).describe()
+    app_details = dxpy.DXApp(dxid=job['executable']).describe()
+
     write_summary_report(
         summary_file,
+        job=job_details,
+        app=app_details,
         assay_config=assay_config,
         manifest=manifest,
         launched_jobs=launched_jobs,

--- a/resources/home/dnanexus/dias_batch/pytest.ini
+++ b/resources/home/dnanexus/dias_batch/pytest.ini
@@ -2,3 +2,4 @@
 filterwarnings =
     ignore:.*DeprecationWarning.*
     ignore:.*U.*mode is deprecated:DeprecationWarning
+    ignore:.*invalid escape sequence.*

--- a/resources/home/dnanexus/dias_batch/tests/test_data/example_config.json
+++ b/resources/home/dnanexus/dias_batch/tests/test_data/example_config.json
@@ -16,7 +16,8 @@
         "workflow_2": {
             "inputs": {
                 "stage_1.input_1": "INPUT-exons_nirvana",
-                "stage_2.input_1": "INPUT-exonsfile"
+                "stage_2.input_1": "INPUT-exonsfile",
+                "stage2.input_2": "other_non_reference_input"
             }
         }
     }

--- a/resources/home/dnanexus/dias_batch/tests/test_data/example_filled_config.json
+++ b/resources/home/dnanexus/dias_batch/tests/test_data/example_filled_config.json
@@ -41,7 +41,8 @@
               "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
               "id": "file-GF611Z8433Gf99pBPbJkV7bq"
             }
-          }
+          },
+          "stage2.input_2": "other_non_reference_input"
         }
       }
     }

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -222,7 +222,7 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
             {
                 'project': 'project-xxx',
                 'id': 'file-xxx',
-                'describe' : {
+                'describe': {
                     'name': 'config1.json',
                     'archivalState': 'live'
                 }
@@ -230,7 +230,7 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
             {
                 'project': 'project-xxx',
                 'id': 'file-xxx',
-                'describe' : {
+                'describe': {
                     'name': 'config2.json',
                     'archivalState': 'archived'
                 }
@@ -254,7 +254,7 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
 
         expected_warning = (
             "Config file not in live state - will not be used: "
-            "config2.json (file-xxx)" 
+            "config2.json (file-xxx)"
         )
 
         assert expected_warning in stdout, (
@@ -326,14 +326,14 @@ class TestDXManageGetFileProjectContext():
             {
                 'project': 'project-xxx',
                 'id': 'file-xxx',
-                'describe' : {
+                'describe': {
                     'archivalState': 'live'
                 }
             },
             {
                 'project': 'project-yyy',
                 'id': 'file-xxx',
-                'describe' : {
+                'describe': {
                     'archivalState': 'live'
                 }
             }
@@ -349,7 +349,7 @@ class TestDXManageGetFileProjectContext():
             'Found file-xxx in 2 projects, using project-xxx as project context'
         )
 
-        if not expected_print in stdout:
+        if expected_print not in stdout:
             errors.append('Did not print expected file project context')
 
         if not returned == mock_find.return_value[0]:
@@ -444,7 +444,7 @@ class TestDXManageFindFiles():
             {
                 'project': 'project-xxx',
                 'id': 'file-xxx',
-                'describe' : {
+                'describe': {
                     'name': 'file1',
                     'archivalState': 'archived',
                     'folder': '/path_to_files/subdir1/app1'
@@ -981,7 +981,7 @@ class TestDXExecuteCNVCalling(unittest.TestCase):
                 'describe': {
                     'name': 'sample3.bam.bai'
                 }
-            }            
+            }
         ]
 
         # first dxpy.describe call is on app ID, second is on job ID
@@ -1125,4 +1125,3 @@ class TestDXExecuteCNVCalling(unittest.TestCase):
                 wait=True,
                 unarchive=False
             )
-

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -234,6 +234,22 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
                     'name': 'config2.json',
                     'archivalState': 'archived'
                 }
+            },
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx',
+                'describe': {
+                    'name': 'config3.json',
+                    'archivalState': 'archival'
+                }
+            },
+            {
+                'project': 'project-xxx',
+                'id': 'file-xxx',
+                'describe': {
+                    'name': 'config4.json',
+                    'archivalState': 'unarchiving'
+                }
             }
         ]
 
@@ -466,10 +482,6 @@ class TestDXManageFindFiles():
         assert expected_warning in stdout, (
             'Expected warning for archived files not printed'
         )
-
-
-
-
 
 
 class TestDXManageReadDXfile():
@@ -932,7 +944,7 @@ class TestDXExecuteCNVCalling(unittest.TestCase):
         self.mock_job = self.job_patch.start()
         self.mock_wait = self.wait_patch.start()
 
-        # our test returns to use for the mocks
+        # Below we define some returns in expected format to use for the mocks
 
         # utils.make_path called twice, once to get path for searching for
         # BAM files then again for setting app output

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -329,8 +329,9 @@ class TestWriteSummaryReport():
         Test when report summaries are passed that these correctly get
         formatted into a markdown table
         """
-        # print(self.summary_contents)
 
+        # markdown table as it should be written to report (without spacing)
+        # as this makes it huge
         correct_table = (
             '+---------+--------------------------+--------------------------+'
             '-----------------------------+||CNV|SNV|mosaic|+=========+='
@@ -464,6 +465,26 @@ class TestFillConfigReferenceInputs():
 
         with pytest.raises(RuntimeError):
             utils.fill_config_reference_inputs(config_copy)
+
+    def test_app_no_inputs(self, capsys):
+        """
+        Test when an app/workflow in the config has no inputs dict defined
+        that we print a warning and continue
+        """
+        config_copy = deepcopy(self.config)
+        config_copy['modes']['app1'] = {}
+
+        utils.fill_config_reference_inputs(config_copy)
+        stdout = capsys.readouterr().out
+
+        correct_print = (
+            "WARNING: app1 in the config does not appear to "
+            "have an 'inputs' key, skipping adding reference files"
+        )
+
+        assert correct_print in stdout, (
+            'App missing inputs did not print expected warning'
+        )
 
 
 class TestParseGenePanels():

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -135,7 +135,7 @@ class TestWriteSummaryReport():
     # minimal dx describe objects of app and job that would be passed
     # into the function from where it is called in dias_batch.main
     job_details = {
-        'id': 'job-GZFXvYj4VjyggGq9xXKb6qp8', 
+        'id': 'job-GZFXvYj4VjyggGq9xXKb6qp8',
         'name': 'eggd_dias_batch',
         'executable': 'app-GZ4v1Q849BP045XxfBF4VzJk',
         'executableName': 'eggd_dias_batch',
@@ -246,7 +246,7 @@ class TestWriteSummaryReport():
         start = self.summary_contents.index('Job inputs:')
         end = self.summary_contents.index('Total number of samples in manifest: 4')
 
-        written_inputs = self.summary_contents[start + 1 : end]
+        written_inputs = self.summary_contents[start + 1: end]
         written_inputs = sorted([
             x.replace('\t', '') for x in written_inputs if x
         ])
@@ -267,7 +267,7 @@ class TestWriteSummaryReport():
             if x.startswith('Total number of samples in manifest')
         ]
 
-        assert int(samples[0][-1])==4, (
+        assert int(samples[0][-1]) == 4, (
             'Total no. samples wrongly parsed from manifest'
         )
 
@@ -295,7 +295,7 @@ class TestWriteSummaryReport():
         """
         Test that if errors were generated during launching of each modes
         jobs that these are written into the file
-        """        
+        """
         # get errors for SNV and CNV written to report
         snv_errors_idx = self.summary_contents.index(
             'Errors in launching SNV reports:'

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -783,6 +783,21 @@ class TestParseManifest:
             utils.parse_manifest(data)
 
 
+    def test_split_tests_called(self):
+        """
+        Test when split_tests specified it gets called
+        """
+        manifest, _ = utils.parse_manifest(
+            contents=self.epic_data,
+            split_tests=True
+        )
+
+        assert manifest['424487111-53214R00111']['tests'] == [
+            ['R208.1'], ['R216.1']
+        ], (
+            'Splitting tests when parsing manifest not as expected'
+        )
+
 class TestFilterManifestSamplesByFiles():
     """
     Tests for utils.filter_manifest_samples_by_files()

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -661,6 +661,22 @@ class TestParseManifest:
         )
 
 
+    def test_gemini_invalid_codes_added_as_is(self):
+        """
+        Invalid test codes will be gathered up and raised as a single error
+        in utils.check_manifest_valid_test_codes, check that if an invalid
+        code is provided that it is written out as found
+        """
+        manifest = deepcopy(self.gemini_data)
+        manifest.append('anotherSample\tnotValidTest')
+
+        manifest, _ = utils.parse_manifest(manifest)
+
+        assert manifest['anotherSample']['tests'] == [['notValidTest']], (
+            'Invalid test code not kept correctly in manifest'
+        )
+
+
     def test_epic_correct_number_lines_parsed(self):
         """
         Test when reading Epic manifest we get the correct number of
@@ -797,6 +813,7 @@ class TestParseManifest:
         ], (
             'Splitting tests when parsing manifest not as expected'
         )
+
 
 class TestFilterManifestSamplesByFiles():
     """

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1173,6 +1173,7 @@ class TestAddPanelsAndIndicationsToManifest():
                 genepanels=self.genepanels
             )
 
+
     def test_correct_indications_panels(self):
         """
         Test that the correct panel and indication strings are added in for
@@ -1255,3 +1256,47 @@ class TestAddPanelsAndIndicationsToManifest():
         assert manifest == correct_manifest, (
             'Clinical indications and panels incorrectly added to manifest'
         )
+
+
+    def test_hgnc_ids_added(self):
+        """
+        HGNC IDs should be added to clinical indications and panels lists
+        as is, test this happens
+        """
+        manifest = deepcopy(self.manifest)
+        manifest['424487111-53214R00111']['tests'] = [['_HGNC:12345']]
+
+        manifest = utils.add_panels_and_indications_to_manifest(
+            manifest=manifest,
+            genepanels=self.genepanels
+        )
+
+        correct_added = {
+            'tests': [['_HGNC:12345']],
+            'indications': [['_HGNC:12345']],
+            'panels': [['_HGNC:12345']]
+        }
+
+        assert manifest['424487111-53214R00111'] == correct_added, (
+            'Clinical indication and / or panel wrongly added for HGNC ID'
+        )
+
+
+    def test_error_raised_invalid_test(self):
+        """
+        Test RuntimeError raised if invalid test code makes it through
+        """
+        manifest = deepcopy(self.manifest)
+        manifest['424487111-53214R00111']['tests'] = [['invalidTestCode']]
+
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                'Error occured selecting test from genepanels '
+                'for test invalidTestCode'
+            )
+        ):
+            utils.add_panels_and_indications_to_manifest(
+                manifest=manifest,
+                genepanels=self.genepanels
+            )

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 import concurrent.futures
 import json
 import os
-from packaging.version import Version
 import re
 import sys
 from time import sleep
@@ -14,10 +13,15 @@ from timeit import default_timer as timer
 from typing import Tuple
 
 import dxpy
+from packaging.version import Version
 import pandas as pd
 
-from .utils import filter_manifest_samples_by_files, make_path, \
-    prettier_print, time_stamp, check_report_index
+from .utils import (
+    check_report_index,
+    filter_manifest_samples_by_files,
+    make_path,
+    prettier_print
+)
 
 # for prettier viewing in the logs
 pd.set_option('display.max_rows', 100)

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -111,8 +111,8 @@ class DXManage():
         for file in files:
             if not file['describe']['archivalState'] == 'live':
                 print(
-                    "Config file not in live state - will not be used:"
-                    f"{file['describe']['name']} ({file['id']}"
+                    "Config file not in live state - will not be used: "
+                    f"{file['describe']['name']} ({file['id']})"
                 )
                 continue
 
@@ -347,11 +347,11 @@ class DXManage():
                         match = True
                         break
 
-                if match:
+                if match and dx_file not in not_live_filtered:
                     # this file is archived and in one of our samples
                     not_live_filtered.append(dx_file)
 
-            not_live = set(not_live_filtered)
+            not_live = not_live_filtered
 
         if not not_live:
             # nothing archived that we need :dancing_penguin:

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -512,7 +512,8 @@ class DXExecute():
     """
     Methods for handling exeuction of apps / worklfows
     """
-    def cnv_calling(self,
+    def cnv_calling(
+            self,
             config,
             single_output_dir,
             exclude,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -860,7 +860,7 @@ class DXExecute():
             if manifest_no_mosdepth:
                 errors[
                     f"Samples in manifest with no mosdepth files found "
-                    f"({len(manifest_no_mosdepth)}):"
+                    f"({len(manifest_no_mosdepth)})"
                 ] = manifest_no_mosdepth
 
             print(
@@ -890,13 +890,13 @@ class DXExecute():
         if manifest_no_match:
             errors[
                 f"Samples in manifest not matching expected {manifest_source} "
-                f"pattern ({len(manifest_no_match)}) {pattern}:"
+                f"pattern ({len(manifest_no_match)}) {pattern}"
             ] = manifest_no_match
 
         if manifest_no_vcf:
             errors[
                 f"Samples in manifest with no VCF found "
-                f"({len(manifest_no_vcf)}):"
+                f"({len(manifest_no_vcf)})"
             ] = manifest_no_vcf
 
 

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
 import json
-import os
 from pprint import PrettyPrinter
 import re
 from time import strftime, localtime

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -534,7 +534,7 @@ def parse_manifest(contents, split_tests=False) -> Tuple[pd.DataFrame, str]:
         raise RuntimeError("Manifest file provided does not seem valid")
 
     if split_tests:
-        manifest = split_manifest_tests(manifest)
+        data = split_manifest_tests(data)
 
     samples = ('\n\t').join([
         f"{x[0]} -> {x[1]['tests']}" for x in data.items()
@@ -760,6 +760,7 @@ def split_manifest_tests(data) -> dict:
         mapping of SampleID: 'tests': [testCodes] with all codes are sub lists
     """
     split_data = defaultdict(lambda: defaultdict(list))
+
     for sample, test_codes in data.items():
         all_split_test_codes = []
         for test_list in test_codes['tests']:

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -459,7 +459,7 @@ def parse_manifest(contents, split_tests=False) -> Tuple[pd.DataFrame, str]:
                     # when we validate all test codes against genepanels
                     # in utils.check_manifest_valid_test_codes()
                     code = test_code
-
+                
                 data[sample[0]]['tests'][0].append(code)
 
         manifest_source = 'Gemini'
@@ -691,11 +691,6 @@ def check_manifest_valid_test_codes(manifest, genepanels) -> dict:
 
             for test in test_list:
                 if test in genepanels_test_codes or re.search(r'HGNC:[\d]+', test):
-                    #TODO: should we check that we have a transcript assigned
-                    # to this HGNC ID?
-                    if re.search(r'HGNC:[\d]+', test):
-                        # ensure HGNC IDs have an _ prefix for generate_bed
-                        test = f"_{test.lstrip('_')}"
                     valid_tests.append(test)
                 elif test == 'Research Use':
                     # more Epic weirdness, chuck these out but don't break

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -81,7 +81,7 @@ def check_report_index(name, reports) -> int:
     return suffix + 1
 
 
-def write_summary_report(output, manifest=None, **summary) -> None:
+def write_summary_report(output, job, app, manifest=None, **summary) -> None:
     """
     Write output summary file with jobs launched and any errors etc.
 
@@ -89,6 +89,10 @@ def write_summary_report(output, manifest=None, **summary) -> None:
     ----------
     output : str
         name for output file
+    job : dict
+        details from dxpy.describe() call on job ID
+    app : dict
+        details from dxpy.describe() call on app ID
     manifest : dict
         mapping of samples in manifest -> requested test codes
     summary : kwargs
@@ -99,9 +103,7 @@ def write_summary_report(output, manifest=None, **summary) -> None:
     {output}.txt file of launched job summary
     """
     print(f"\n \nWriting summary report to {output}")
-    batch_job_id = os.environ.get('DX_JOB_ID')
-    job = dxpy.bindings.dxjob.DXJob(dxid=batch_job_id).describe()
-    app = dxpy.bindings.dxapp.DXApp(dxid=job['executable']).describe()
+
     time = strftime('%Y-%m-%d %H:%M:%S', localtime(job['created'] / 1000))
     inputs = job['runInput']
 
@@ -118,7 +120,7 @@ def write_summary_report(output, manifest=None, **summary) -> None:
 
     with open(output, 'w') as file_handle:
         file_handle.write(
-            f"\nJobs launched from {app['name']} ({app['version']}) at {time} "
+            f"Jobs launched from {app['name']} ({app['version']}) at {time} "
             f"by {job['launchedBy'].replace('user-', '')} in {job['id']}\n"
         )
 

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -459,7 +459,7 @@ def parse_manifest(contents, split_tests=False) -> Tuple[pd.DataFrame, str]:
                     # when we validate all test codes against genepanels
                     # in utils.check_manifest_valid_test_codes()
                     code = test_code
-                
+
                 data[sample[0]]['tests'][0].append(code)
 
         manifest_source = 'Gemini'
@@ -900,4 +900,3 @@ def add_panels_and_indications_to_manifest(manifest, genepanels) -> dict:
     PPRINT(manifest_with_panels)
 
     return manifest_with_panels
-

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -106,16 +106,6 @@ def write_summary_report(output, job, app, manifest=None, **summary) -> None:
 
     time = strftime('%Y-%m-%d %H:%M:%S', localtime(job['created'] / 1000))
     inputs = job['runInput']
-
-    # nicer formatting of inputs for job report
-    if inputs.get('manifest_file'):
-        inputs['manifest_file'] = dxpy.describe(
-            inputs['manifest_file']['$dnanexus_link'])['name']
-
-    if inputs.get('assay_config_file'):
-        inputs['assay_config_file'] = dxpy.describe(
-            inputs['assay_config_file']['$dnanexus_link'])['name']
-
     inputs = "\n\t".join([f"{x[0]}: {x[1]}" for x in sorted(inputs.items())])
 
     with open(output, 'w') as file_handle:
@@ -144,21 +134,12 @@ def write_summary_report(output, job, app, manifest=None, **summary) -> None:
             )
 
         launched_jobs = '\n\t'.join([
-            f"{k} : {len(v)} jobs" for k, v
-            in summary.get('launched_jobs').items()
+            f"{k} : {len(v)} jobs" if len(v) > 1
+            else f"{k} : {len(v)} job"
+            for k, v in summary.get('launched_jobs').items()
         ])
 
         file_handle.write(f"\nTotal jobs launched:\n\t{launched_jobs}\n")
-
-        if summary.get('invalid_tests'):
-            invalid_tests = '\n\t'.join([
-                f"{k} : {v}" for k, v
-                in summary.get('invalid_tests').items()
-            ])
-
-            file_handle.write(
-                f"\nInvalid tests excluded from manifest:\n\t{invalid_tests}\n"
-            )
 
         report_summaries = {
             "snv_report_errors": "SNV",


### PR DESCRIPTION
## Summary
More unit tests, test coverage now at 100% for all of `utils.py` and 100% for `dx_requests.DXManage`, plus addition unit tests started for `dx_requests.DXExecute.cnv_calling`

## Changes
- shifted getting job and app details to `dias_batch.main` from `utils.write_summary_report` to make testing easier
- Additional unit tests for `dx_requests.DXManage`
  - switched to use of `setUp()` and `tearDown()` test functions to reduce use of decorators (will refactor more later to clean up where needed)
- additional tests for `utils.py`
  - tests for summary report writing
  - other minor tests to get to 100% coverage
-  fix making cnv_calling output path have consistent time stamp as other jobs

```
---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                                           Stmts   Miss  Cover
----------------------------------------------------------------------------------
resources/home/dnanexus/dias_batch/__init__.py                     0      0   100%
resources/home/dnanexus/dias_batch/dias_batch.py                 146     96    34%
resources/home/dnanexus/dias_batch/tests/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py       63      0   100%
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py     245      2    99%
resources/home/dnanexus/dias_batch/tests/test_utils.py           308      4    99%
resources/home/dnanexus/dias_batch/utils/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/utils/dx_requests.py          331    137    59%
resources/home/dnanexus/dias_batch/utils/utils.py                255      0   100%
----------------------------------------------------------------------------------
TOTAL                                                           1348    239    82%


================================================================== 84 passed in 3.33s ==================================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/128)
<!-- Reviewable:end -->
