### PR TITLE
Improve handling of files for unarchiving

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1177,6 +1177,50 @@ class TestDXExecuteCNVCalling(unittest.TestCase):
             )
 
 
+class TestDXExecuteArtemis():
+    """
+    Test for DXExecute.artemis
+
+    This is a reasonably pointless test since we're going to patch all
+    the function calls it makes, which is all this function does, but also
+    I want the sweet dopamine hit of it going green in the test report so
+    here it is ¯\_(ツ)_/¯
+    """
+
+    @patch('utils.dx_requests.make_path')
+    @patch('utils.dx_requests.dxpy.DXApp.describe')
+    @patch('utils.dx_requests.dxpy.DXApp')
+    def test_called(
+        self,
+        mock_app,
+        mock_describe,
+        mock_path
+    ):
+        """
+        Test when we run artemis that we get back the job ID which is stored
+        as '_dxid' attribute of the DXJob dx object
+        """
+        # patch in a DXJob object to the return of calling DXApp.run()
+        job_obj = dxpy.DXJob('job-QaTZ9qEwkEsovKLs14DSdNqb')
+        job_obj._dxid = 'job-QaTZ9qEwkEsovKLs14DSdNqb'
+        mock_app.return_value.run.return_value = job_obj
+
+        job = DXExecute().artemis(
+            single_output_dir='/output_path/',
+            app_id='app-xxx',
+            dependent_jobs=[],
+            start='230922_1012',
+            qc_xlsx='file-xxx',
+            capture_bed='file-xxx',
+            snv_output=None,
+            cnv_output=None
+        )
+
+        assert job == 'job-QaTZ9qEwkEsovKLs14DSdNqb', (
+            'Job ID returned from running Artemis incorrect'
+        )
+
+
 class TestDXExecuteTerminate(unittest.TestCase):
     """
     Unit tests for DXExecute.terminate

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -716,8 +716,8 @@ class TestDXManageCheckArchivalState():
     def test_error_raised_when_non_live_files_can_not_be_unarchived(self):
         """
         When non-live files are found their archivalState is checked and
-        those in 'archiving' or 'unarchiving' states are removed from
-        those to request unarchiving on, as this would raise an error.
+        those in 'unarchiving' state are removed from those to request
+        unarchiving on, as this would raise an error.
 
         If no files are left to unarchive after removing these an error
         should be raised as we are in a state of not being able to run
@@ -738,13 +738,6 @@ class TestDXManageCheckArchivalState():
                 'describe': {
                     'name': 'sample2-file1',
                     'archivalState': 'unarchiving'
-                }
-            },
-            {
-                'id': 'file-xxx',
-                'describe': {
-                    'name': 'sample3-file1',
-                    'archivalState': 'archiving'
                 }
             }
         ]

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -713,6 +713,51 @@ class TestDXManageCheckArchivalState():
             )
 
 
+    def test_error_raised_when_non_live_files_can_not_be_unarchived(self):
+        """
+        When non-live files are found their archivalState is checked and
+        those in 'archiving' or 'unarchiving' states are removed from
+        those to request unarchiving on, as this would raise an error.
+
+        If no files are left after removing these and error should be
+        raised as we are in a state of not being able to run jobs and
+        also not able to call unarchiving
+        """
+        # minimal test file objects where one file is unarchiving and
+        # another is archiving
+        files = [
+            {
+                'id': 'file-xxx',
+                'describe': {
+                    'name': 'sample1-file1',
+                    'archivalState': 'live'
+                }
+            },
+            {
+                'id': 'file-xxx',
+                'describe': {
+                    'name': 'sample2-file1',
+                    'archivalState': 'unarchiving'
+                }
+            },
+            {
+                'id': 'file-xxx',
+                'describe': {
+                    'name': 'sample3-file1',
+                    'archivalState': 'archiving'
+                }
+            }
+        ]
+
+        with pytest.raises(
+            RuntimeError,
+            match='non-live files not in a state that can be unarchived'
+        ):
+            DXManage().check_archival_state(
+                files=files,
+                unarchive=True
+            )
+
 
     @patch('utils.dx_requests.DXManage.unarchive_files')
     def test_unarchive_files_called_when_specified(self, mock_unarchive):

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -719,9 +719,9 @@ class TestDXManageCheckArchivalState():
         those in 'archiving' or 'unarchiving' states are removed from
         those to request unarchiving on, as this would raise an error.
 
-        If no files are left after removing these and error should be
-        raised as we are in a state of not being able to run jobs and
-        also not able to call unarchiving
+        If no files are left to unarchive after removing these an error
+        should be raised as we are in a state of not being able to run
+        jobs and also not able to call unarchiving
         """
         # minimal test file objects where one file is unarchiving and
         # another is archiving

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -322,12 +322,13 @@ class DXManage():
 
         Files may be in the following states:
 
-        - live => nothing to do
-        - archival => archiving has been requested but not yet happened
+        - live -> nothing to do
+        - archival -> archiving has been requested but not yet happened
             and / or not all instances of the file have been archived =>
             can be unarchived
-        - archived => file fully archived, will take time to unarchive fully
-        - unarchiving => unarchiving has already been requested
+        - archived -> file fully archived, will take time to unarchive fully
+        - unarchiving -> already requested unarchiving but not yet
+            completed, skip trying to unarchive again 
 
         Parameters
         ---------

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1160,7 +1160,7 @@ class DXExecute():
         str
             job ID of launched job
         """
-        details = dxpy.bindings.dxapp.DXApp(app_id).describe()
+        details = dxpy.DXApp(app_id).describe()
         path = make_path(single_output_dir, details['name'], start)
 
         app_input = {
@@ -1170,7 +1170,7 @@ class DXExecute():
             "bed_file": capture_bed
         }
 
-        job = dxpy.bindings.dxapp.DXApp(dxid=app_id).run(
+        job = dxpy.DXApp(dxid=app_id).run(
             app_input=app_input,
             project=os.environ.get('DX_PROJECT_CONTEXT_ID'),
             folder=path,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -318,7 +318,16 @@ class DXManage():
     def check_archival_state(self, files, unarchive, samples=None) -> None:
         """
         Check archival state of n files, to be used before attempting
-        to launch jobs to ensure nothing fails due to archived files
+        to launch jobs to ensure nothing fails due to archived files.
+
+        Files may be in the following states:
+
+        - live => nothing to do
+        - archival => archiving has been requested but not yet happened
+            and / or not all instances of the file have been archived =>
+            can be unarchived
+        - archived => file fully archived, will take time to unarchive fully
+        - unarchiving => unarchiving has already been requested
 
         Parameters
         ---------
@@ -366,14 +375,11 @@ class DXManage():
         # (i.e. in 'unarchiving' or 'archival' states) since an error
         # will be raised if we try unarchive these in this state
         unarchiving = []
-        archiving = []
         to_unarchive = []
 
         for file in not_live:
             if file['describe']['archivalState'] == 'unarchiving':
                 unarchiving.append(file)
-            elif file['describe']['archivalState'] == 'archiving':
-                archiving.append(file)
             else:
                 to_unarchive.append(file)
 
@@ -389,7 +395,6 @@ class DXManage():
         )
 
         print(f"{len(unarchiving)} files are currently in state 'unarchiving'")
-        print(f"{len(archiving)} files are currently in state 'archiving'")
         print(f"{len(to_unarchive)} files are in state 'archived'")
 
         if unarchive:

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -372,9 +372,8 @@ class DXManage():
             print("No required files in archived state")
             return
 
-        # check for files currently unarchiving or being archived
-        # (i.e. in 'unarchiving' or 'archival' states) since an error
-        # will be raised if we try unarchive these in this state
+        # check for files currently unarchiving (i.e. in 'unarchiving') since
+        # an error will be raised if we try unarchive these in this state
         unarchiving = []
         to_unarchive = []
 
@@ -795,7 +794,7 @@ class DXExecute():
         # set up required files for each running mode
         if mode == 'CNV':
             # get required files
-            job_details = dxpy.bindings.dxjob.DXJob(dxid=call_job_id).describe()
+            job_details = dxpy.DXJob(dxid=call_job_id).describe()
 
             vcf_input_field = 'stage-cnv_vep.vcf'
 
@@ -1088,7 +1087,7 @@ class DXExecute():
 
 
                 # now we can finally run the reports workflow
-                job_handle = dxpy.bindings.dxworkflow.DXWorkflow(
+                job_handle = dxpy.DXWorkflow(
                     dxid=workflow_id
                 ).run(
                     workflow_input=input,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1193,9 +1193,9 @@ class DXExecute():
         def terminate_one(job) -> None:
             """dx call to terminate single job"""
             if job.startswith('job'):
-                dxpy.bindings.dxjob.DXJob(dxid=job).terminate()
+                dxpy.DXJob(dxid=job).terminate()
             else:
-                dxpy.bindings.dxanalysis.DXAnalysis(dxid=job).terminate()
+                dxpy.DXAnalysis(dxid=job).terminate()
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
             concurrent_jobs = {


### PR DESCRIPTION
## Changes
- handle files in state of `archiving` or `unarchiving` better to not raise an error
- specify project to call `DXFile.unarchive()` within
- add unit test for the above
```
---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                                           Stmts   Miss  Cover
----------------------------------------------------------------------------------
resources/home/dnanexus/dias_batch/__init__.py                     0      0   100%
resources/home/dnanexus/dias_batch/dias_batch.py                 146     96    34%
resources/home/dnanexus/dias_batch/tests/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py       63      0   100%
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py     249      2    99%
resources/home/dnanexus/dias_batch/tests/test_utils.py           308      4    99%
resources/home/dnanexus/dias_batch/utils/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/utils/dx_requests.py          342    137    60%
resources/home/dnanexus/dias_batch/utils/utils.py                254      0   100%
----------------------------------------------------------------------------------
TOTAL                                                           1362    239    82%


========================================================================================= 85 passed in 3.03s ==========================================================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/129)
<!-- Reviewable:end -->
