### PR TITLE
Unit tests for DXExecute.reports_workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,8 +175,8 @@ The top level section should be structured as follows:
         "exonsfile": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gf99pBPbJkV7bq"
     },
     "name_patterns": {
-        "Epic": "^[\\d\\w]+-[\\d\\w]+[-_]",
-        "Gemini": "^X[\\d]+[-_]"
+        "Epic": "^[\\d\\w]+-[\\d\\w]+",
+        "Gemini": "^X[\\d]+"
     },
     ...
 ```

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -156,3 +156,14 @@ class TestCheckInputs():
         assert check.errors == correct_error, (
             "Error not raised for CNV reports missing CNV call / job ID"
         )
+
+
+class TestMain():
+    """
+    Tests for dias_batch.main
+    
+    This is the main entry point into the app, tests are just to show that
+    functions are called when expected as there is little other logic in here
+    """
+
+

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -165,5 +165,4 @@ class TestMain():
     This is the main entry point into the app, tests are just to show that
     functions are called when expected as there is little other logic in here
     """
-
-
+    pass

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1315,7 +1315,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         we raise an error if this is missing
         """
         pass
-    
+
 
     def test_cnv_mode_correct_vcf_name_pattern_used(self):
         """
@@ -1323,7 +1323,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         config, check that the correct one is selected and used
         """
         pass
-    
+
 
     def test_cnv_mode_error_raised_when_missing_vcf_files(self):
         """
@@ -1340,7 +1340,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         """
         pass
 
-    
+
     def test_cnv_mode_total_file_prints_correct(self):
         """
         There's a print with total files found, check these are correct

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1247,6 +1247,10 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
 
 
     def setUp(self):
+        """
+        Set up all of the functions to mock and some of their patched in
+        return values that can be applied to multiple tests
+        """
         self.find_patch = mock.patch('utils.dx_requests.DXManage.find_files')
         self.job_patch = mock.patch('utils.dx_requests.dxpy.DXJob')
         self.filter_manifest_patch = mock.patch(
@@ -1275,9 +1279,10 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_describe = self.describe_patch.start()
         self.mock_timer = self.timer_patch.start()
 
-        # Generalised expected returns for each of the function calls,
-        # these will be patched over individually to adjust for expected
-        # environment of each test
+
+        # Below are some generalised expected returns for each of the
+        # function calls, these will be patched over individually to
+        # adjust for expected environment of each test
 
         # mock of filtering manifest where no invalid samples found
         self.mock_filter_manifest.return_value = [

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1190,6 +1190,11 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
     be a lot of mocking and patching returns etc. to test all the
     conditional behaviour.
     """
+    # example assay config
+    assay_config = {
+        
+    }
+
     def setUp(self):
         self.find_patch = mock.patch('utils.dx_requests.DXManage.find_files')
         self.job_patch = mock.patch('utils.dx_requests.dxpy.DXJob')
@@ -1314,7 +1319,21 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         Intervals bed should always be found from CNV calling, check
         we raise an error if this is missing
         """
-        pass
+        with pytest.raises(
+            RuntimeError,
+            match=f'Failed to find excluded intervals bed file from job-QaTZ9qEwkEsovKLs14DSdNqb'
+        ):
+            DXExecute().reports_workflow(
+                mode='CNV',
+                workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+                single_output_dir='/path_to_single/',
+                manifest={},
+                manifest_source='Gemini',
+                config={},
+                start='230925_0943',
+                name_patterns={'Gemini': 'X[\d]+'},
+                call_job_id='job-QaTZ9qEwkEsovKLs14DSdNqb'
+            )
 
 
     def test_cnv_mode_correct_vcf_name_pattern_used(self):
@@ -1346,6 +1365,17 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         There's a print with total files found, check these are correct
         """
         pass
+
+
+    def test_snv_mode_correct_vcf_name_pattern_used(self):
+        """
+        When searching for VCF files a pattern is used from the assay
+        config, check that the correct one is selected and used
+        """
+        pass
+
+    
+
 
 
 class TestDXExecuteArtemis():

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -10,6 +10,7 @@ Functions not covered by unit tests:
 """
 from copy import deepcopy
 import os
+import re
 import sys
 import unittest
 from unittest import mock
@@ -24,12 +25,9 @@ sys.path.append(os.path.abspath(
     os.path.join(os.path.realpath(__file__), '../../')
 ))
 
+from utils import utils
 from utils.dx_requests import DXExecute, DXManage
 
-
-TEST_DATA_DIR = (
-    os.path.join(os.path.dirname(__file__), 'test_data')
-)
 
 class TestDXManageReadAssayConfigFile():
     """
@@ -1214,7 +1212,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                 "inputs": {
                     "stage-rpt_vep.vcf": {
                         "folder": "sentieon-dnaseq",
-                        "name": "^[^\\.]*(?!\\.g)\\.vcf(\\.gz)?$"
+                        "name": ".vcf"
                     },
                     "stage-rpt_athena.mosdepth_files": {
                         "folder": "eggd_mosdepth",
@@ -1247,6 +1245,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         },
     }
 
+
     def setUp(self):
         self.find_patch = mock.patch('utils.dx_requests.DXManage.find_files')
         self.job_patch = mock.patch('utils.dx_requests.dxpy.DXJob')
@@ -1262,6 +1261,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.path_patch = mock.patch('utils.dx_requests.make_path')
         self.index_patch = mock.patch('utils.dx_requests.check_report_index')
         self.workflow_patch = mock.patch('utils.dx_requests.dxpy.DXWorkflow')
+        self.describe_patch = mock.patch('utils.dx_requests.dxpy.describe')
         self.timer_patch = mock.patch('utils.dx_requests.timer')
 
         self.mock_find = self.find_patch.start()
@@ -1272,15 +1272,88 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_path = self.path_patch.start()
         self.mock_index = self.index_patch.start()
         self.mock_workflow = self.workflow_patch.start()
+        self.mock_describe = self.describe_patch.start()
         self.mock_timer = self.timer_patch.start()
 
         # Generalised expected returns for each of the function calls,
         # these will be patched over individually to adjust for expected
         # environment of each test
 
-        # 
+        # mock of filtering manifest where no invalid samples found
+        self.mock_filter_manifest.return_value = [
+            self.manifest,
+            [],
+            []
+        ]
 
+        # patch of dxpy.describe when called on workflow to return name
+        # for setting output paths and job names
+        self.mock_describe.return_value = {
+            'name': 'reports_workflow'
+        }
 
+        # patch of adding vcfs to the manifest (i.e. manifest with describe
+        # output of the vcf file added to the manifest under 'vcf' key)
+        self.mock_filter_manifest.return_value = [
+            {
+                "X1234": {
+                    "tests": [["R207.1"]],
+                    "panels": [
+                        ["Inherited ovarian cancer (without breast cancer)_4.0"]
+                    ],
+                    "indications": [[
+                        "R207.1_Inherited ovarian cancer (without breast cancer)_P"
+                    ]],
+                    "vcf": [
+                        {
+                            'project': 'project-xxx',
+                            'id': 'file-xxx',
+                            'describe': {
+                                'name': 'X1234_markdup.vcf'
+                            }
+                        }
+                    ],
+                    "mosdepth": [
+                        {
+                            'project': 'project-xxx',
+                            'id': 'file-xxx',
+                            'describe': {
+                                'name': 'X1234.per-base.bed.gz'
+                            }
+                        }
+                    ]
+                },
+                "X5678": {
+                    "tests": [["R134.1"]],
+                    "panels": [
+                        ["Familial hypercholesterolaemia (GMS)_2.0"]
+                    ],
+                    "indications": [
+                        ["R134.1_Familial hypercholesterolaemia_P"]
+                    ],
+                    "vcf": [
+                        {
+                            'project': 'project-xxx',
+                            'id': 'file-xxx',
+                            'describe': {
+                                'name': 'X5678_markdup.vcf'
+                            }
+                        }
+                    ],
+                    "mosdepth": [
+                        {
+                            'project': 'project-xxx',
+                            'id': 'file-xxx',
+                            'describe': {
+                                'name': 'X5678.per-base.bed.gz'
+                            }
+                        },
+                    ]
+                },
+            },
+            [],
+            []
+        ]
 
 
     def tearDown(self):
@@ -1292,6 +1365,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_path.stop()
         self.mock_index.stop()
         self.mock_workflow.stop()
+        self.mock_describe.stop()
         self.mock_timer.stop()
 
 
@@ -1435,25 +1509,381 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         are correctly excluded from the manifest (these will have been
         samples excluded from CNV calling)
         """
-        pass
+        # patch in returned bed and vcfs
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'project': 'project-xxx',
+                'id': 'file-xxx'
+            }],
+            [
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X1234_markdup.vcf'
+                    }
+                },
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X5678_markdup.vcf'
+                    }
+                }
+            ]
+        ]
+
+        DXExecute().reports_workflow(
+            mode='CNV',
+            workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+            single_output_dir='/path_to_single/',
+            manifest=self.manifest,
+            manifest_source='Gemini',
+            config=self.assay_config['modes']['cnv_reports'],
+            start='230925_0943',
+            name_patterns=self.assay_config['name_patterns'],
+            call_job_id='job-QaTZ9qEwkEsovKLs14DSdNqb',
+            exclude=['X1234']
+        )
+
+        # check that excluded sample is dumped to stdout, about the best
+        # test we can do here since we patch over the manifest later when
+        # filtering by files so would be pretty circular to test this
+        stdout = self.capsys.readouterr().out
+
+        assert "Excluded 1 samples from manifest: ['X1234']" in stdout, (
+            'Exclude sample not correctly excluded'
+        )
 
 
-    def test_cnv_mode_total_file_prints_correct(self):
+    def test_snv_mode_error_raised_when_missing_vcfs(self):
         """
-        There's a print with total files found, check these are correct
+        Check correct error is raised if no VCFs are found in given dir
         """
-        pass
+        self.mock_find.return_value = []
+
+        expected_error = (
+            "Found no vcf files! SNV reports in /path_to_single/ and subdir "
+            "sentieon-dnaseq with pattern .vcf"
+        )
+
+        with pytest.raises(RuntimeError, match=expected_error):
+            DXExecute().reports_workflow(
+                mode='SNV',
+                workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+                single_output_dir='/path_to_single/',
+                manifest=self.manifest,
+                manifest_source='Gemini',
+                config=self.assay_config['modes']['snv_reports'],
+                start='230925_0943',
+                name_patterns=self.assay_config['name_patterns']
+            )
 
 
-    def test_snv_mode_correct_vcf_name_pattern_used(self):
+    def test_snv_mode_error_raised_when_missing_mosdepth_files(self):
         """
-        When searching for VCF files a pattern is used from the assay
-        config, check that the correct one is selected and used
+        Check correct error is raised if no mosdepth files are found in given dir
         """
-        pass
+        # minimal return of find with vcf structure to pass to simulating
+        # no mosdepth files
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'describe': {
+                    'name': 'sample.vcf'
+                }
+            }],
+            []
+        ]
 
+        expected_error = (
+            "Found no mosdepth files\! SNV reports in \/path_to_single\/ "
+            "and subdir eggd_mosdepth with pattern per\-base\.bed\.gz\$\|"
+            "reference\.txt\$"
+        )
+
+        with pytest.raises(RuntimeError, match=expected_error):
+            DXExecute().reports_workflow(
+                mode='SNV',
+                workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+                single_output_dir='/path_to_single/',
+                manifest=self.manifest,
+                manifest_source='Gemini',
+                config=self.assay_config['modes']['snv_reports'],
+                start='230925_0943',
+                name_patterns=self.assay_config['name_patterns']
+            )
+
+    def test_snv_mode_filter_manifest_by_files_is_called(self):
+        """
+        In SNV mode the manifest should be filtered by samples having
+        mosdepth files (which also adds the DXObjects to the sample),
+        check that this function gets called
+        """
+        # minimal mock of returned vcf and mosdepth files
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'describe': {
+                    'name': 'sample.vcf'
+                }
+            }],
+            [
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X1234.per-base.bed.gz'
+                    }
+                },
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X5678.per-base.bed.gz'
+                    }
+                }
+            ]
+        ]
+
+        DXExecute().reports_workflow(
+            mode='SNV',
+            workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+            single_output_dir='/path_to_single/',
+            manifest=self.manifest,
+            manifest_source='Gemini',
+            config=self.assay_config['modes']['snv_reports'],
+            start='230925_0943',
+            name_patterns=self.assay_config['name_patterns']
+        )
+
+        # check we called filter_manifest_samples_by_files() for mosdepth
+        self.mock_filter_manifest.assert_any_call(
+            name='mosdepth',
+            files=mock.ANY,
+            manifest=mock.ANY,
+            pattern=mock.ANY
+        )
+
+
+    def test_samples_no_vcfs_or_mosdepth_files_added_to_errors(self):
+        """
+        Test if any samples in manifest have no vcfs or mosdepth files
+        these get added to the list of returned errors
+        """
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'describe': {
+                    'name': 'sample.vcf'
+                }
+            }],
+            [
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X1234.per-base.bed.gz'
+                    }
+                },
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X5678.per-base.bed.gz'
+                    }
+                }
+            ]
+        ]
+
+        # patch in an error for adding files to the output of
+        # filter_manifest_samples_by_file to check it gets returned
+        return_copy = deepcopy(self.mock_filter_manifest.return_value)
+        return_copy[-2] = ['X1928']
+        return_copy[-1] = ['X1928']
+        self.mock_filter_manifest.return_value = return_copy
+
+        _, errors, _ = DXExecute().reports_workflow(
+            mode='SNV',
+            workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+            single_output_dir='/path_to_single/',
+            manifest=self.manifest,
+            manifest_source='Gemini',
+            config=self.assay_config['modes']['snv_reports'],
+            start='230925_0943',
+            name_patterns=self.assay_config['name_patterns']
+        )
+
+        expected_errors = {
+            (
+                'Samples in manifest not matching expected Gemini pattern '
+                '(1) ^X[\\d]+'
+            ): ['X1928'],
+            'Samples in manifest with no mosdepth files found (1)': ['X1928'],
+            'Samples in manifest with no VCF found (1)': ['X1928']
+        }
+
+        assert errors == expected_errors, (
+            'Expected errors not returned from samples missing files'
+        )
+
+
+    def test_error_raised_if_manifest_empty_after_filtering(self):
+        """
+        Test that if the manifest is empty after filtering against all
+        the different files and patterns that we raise an error since
+        there's nothing to launch
+        """
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'describe': {
+                    'name': 'sample.vcf'
+                }
+            }],
+            [
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X1234.per-base.bed.gz'
+                    }
+                },
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X5678.per-base.bed.gz'
+                    }
+                }
+            ]
+        ]
+
+        self.mock_filter_manifest.return_value = [{}, [], []]
+
+        expected_error = "No samples left after filtering to run SNV reports for"
+
+        with pytest.raises(RuntimeError, match=expected_error):
+            DXExecute().reports_workflow(
+            mode='SNV',
+            workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+            single_output_dir='/path_to_single/',
+            manifest=self.manifest,
+            manifest_source='Gemini',
+            config=self.assay_config['modes']['snv_reports'],
+            start='230925_0943',
+            name_patterns=self.assay_config['name_patterns']
+        )
     
 
+    def test_name_suffix_integer_incremented(self):
+        """
+        When setting the output integer suffix for reports, if more than one
+        job is being launched for the same sample this suffix should get
+        incremented, check this happens
+        """
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'describe': {
+                    'name': 'sample.vcf'
+                }
+            }],
+            [
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X1234.per-base.bed.gz'
+                    }
+                },
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X5678.per-base.bed.gz'
+                    }
+                }
+            ]
+        ]
+
+        self.mock_index.return_value = 1
+
+        # add additional test to manifest for X1234 (just duplicating the
+        # one already added)
+        filled_manifest = deepcopy(self.mock_filter_manifest.return_value)
+        filled_manifest[0]["X1234"]["tests"] = \
+            filled_manifest[0]["X1234"]["tests"] * 2
+        filled_manifest[0]["X1234"]["indications"] = \
+            filled_manifest[0]["X1234"]["indications"] * 2
+        filled_manifest[0]["X1234"]["panels"] = \
+            filled_manifest[0]["X1234"]["panels"] * 2
+
+        self.mock_filter_manifest.return_value = filled_manifest
+
+        _, _, summary = DXExecute().reports_workflow(
+            mode='SNV',
+            workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+            single_output_dir='/path_to_single/',
+            manifest=filled_manifest,
+            manifest_source='Gemini',
+            config=self.assay_config['modes']['snv_reports'],
+            start='230925_0943',
+            name_patterns=self.assay_config['name_patterns']
+        )
+
+        assert summary['SNV']['X1234'] == 'X1234_R207.1_SNV_1\nX1234_R207.1_SNV_2', (
+            'Suffix for repeat sample incorrect'
+        )
+
+
+    def test_sample_limit_works(self):
+        """
+        Test when sample limit is set that it works as expected
+        """
+        self.mock_find.side_effect = [
+            [],
+            [{
+                'describe': {
+                    'name': 'sample.vcf'
+                }
+            }],
+            [
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X1234.per-base.bed.gz'
+                    }
+                },
+                {
+                    'project': 'project-xxx',
+                    'id': 'file-xxx',
+                    'describe': {
+                        'name': 'X5678.per-base.bed.gz'
+                    }
+                }
+            ]
+        ]
+
+        DXExecute().reports_workflow(
+            mode='SNV',
+            workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
+            single_output_dir='/path_to_single/',
+            manifest=self.manifest,
+            manifest_source='Gemini',
+            config=self.assay_config['modes']['snv_reports'],
+            start='230925_0943',
+            name_patterns=self.assay_config['name_patterns'],
+            sample_limit=1
+        )
+
+        stdout = self.capsys.readouterr().out
+
+        assert "Sample limit hit, stopping launching further jobs" in stdout, (
+            "Sample limit param didn't break as expected"
+        )
 
 
 class TestDXExecuteArtemis():

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -982,7 +982,7 @@ class DXExecute():
 
         if not manifest:
             # empty manifest after filtering against files etc
-            error = f"No samples left after filtering to run {mode} reports for"
+            error = f"No samples left after filtering to run {mode} reports on"
 
             raise RuntimeError(error)
 

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -773,7 +773,7 @@ class DXExecute():
             x['describe']['name'] for x in xlsx_reports
         ]
         if xlsx_reports:
-            reports = '\nt\t'.join(sorted(xlsx_reports))
+            reports = '\n\t'.join(sorted(xlsx_reports))
             print(f"xlsx reports found:\n\t{reports}")
 
         if manifest_source == 'Epic':

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -801,23 +801,6 @@ class DXExecute():
             vcf_dir = f"{job_details.get('project')}:{job_details.get('folder')}"
             vcf_name = config.get('inputs').get(vcf_input_field).get('name')
 
-            print("\n \nSearching for VCF files")
-            vcf_files = list(DXManage().find_files(
-                path=vcf_dir,
-                pattern=vcf_name
-            ))
-
-            if not vcf_files:
-                raise RuntimeError(
-                    f"Failed to find vcfs from {call_job_id} ({vcf_dir})"
-            )
-
-            print(
-                "VCFs found:\n\t", '\n\t'.join(
-                    sorted([x['describe']['name'] for x in vcf_files])
-                )
-            )
-
             print('\n \nSearching for excluded intervals bed file')
             excluded_intervals_bed = list(DXManage().find_files(
                 path=f"{job_details.get('project')}:{job_details.get('folder')}",
@@ -836,6 +819,23 @@ class DXExecute():
                     "id": excluded_intervals_bed[0]['id']
                 }
             }
+
+            print("\n \nSearching for VCF files")
+            vcf_files = list(DXManage().find_files(
+                path=vcf_dir,
+                pattern=vcf_name
+            ))
+
+            if not vcf_files:
+                raise RuntimeError(
+                    f"Failed to find vcfs from {call_job_id} ({vcf_dir})"
+            )
+
+            print(
+                "VCFs found:\n\t", '\n\t'.join(
+                    sorted([x['describe']['name'] for x in vcf_files])
+                )
+            )
 
             if exclude:
                 # exclude samples specified and won't have been through CNV

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -806,6 +806,12 @@ class DXExecute():
                 path=vcf_dir,
                 pattern=vcf_name
             ))
+
+            if not vcf_files:
+                raise RuntimeError(
+                    f"Failed to find vcfs from {call_job_id} ({vcf_dir})"
+            )
+
             print(
                 "VCFs found:\n\t", '\n\t'.join(
                     sorted([x['describe']['name'] for x in vcf_files])
@@ -822,10 +828,6 @@ class DXExecute():
             if not excluded_intervals_bed:
                 raise RuntimeError(
                     f"Failed to find excluded intervals bed file from {call_job_id}"
-            )
-            if not vcf_files:
-                raise RuntimeError(
-                    f"Failed to find vcfs from {call_job_id} ({vcf_dir})"
             )
 
             excluded_intervals_bed = {

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -996,8 +996,6 @@ class DXExecute():
         # initialise per sample summary dict from samples in manifest
         sample_summary = {mode: {k: [] for k in manifest.keys()}}
 
-        print(manifest)
-
         # launch reports workflow, once per sample -> set of test codes
         for sample, sample_config in manifest.items():
 


### PR DESCRIPTION
Many more unit tests for `DXExecute.reportsworkflow`, plus some minor changes to raising errors etc
Now at 100% test coverage for dx_requests.py :tada:

```
---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                                           Stmts   Miss  Cover
----------------------------------------------------------------------------------
resources/home/dnanexus/dias_batch/__init__.py                     0      0   100%
resources/home/dnanexus/dias_batch/dias_batch.py                 146     96    34%
resources/home/dnanexus/dias_batch/tests/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py       63      0   100%
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py     400      2    99%
resources/home/dnanexus/dias_batch/tests/test_utils.py           308      4    99%
resources/home/dnanexus/dias_batch/utils/__init__.py               0      0   100%
resources/home/dnanexus/dias_batch/utils/dx_requests.py          343      0   100%
resources/home/dnanexus/dias_batch/utils/utils.py                254      0   100%
----------------------------------------------------------------------------------
TOTAL                                                           1514    102    93%
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/131)
<!-- Reviewable:end -->
