### PR TITLE
fix for broken tests in test_dx_requests.py

### DIFF
--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -126,8 +126,10 @@ class DXManage():
                 continue
 
             config_data = json.loads(
-                dxpy.bindings.dxfile.DXFile(
-                    project=file['project'], dxid=file['id']).read())
+                dxpy.DXFile(
+                    project=file['project'],
+                    dxid=file['id']
+                ).read())
 
             if not config_data.get('assay') == assay:
                 continue


### PR DESCRIPTION
Fix broken tests in `test_dx_requests.py`

```
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch, configfile: pytest.ini
plugins: Faker-14.0.0, mock-3.11.1, cov-4.0.0
collected 103 items                                                                                                                   

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_invalid_assay_str_error_raised PASSED        [  0%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_assay_config_dir PASSED                      [  1%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_check_single_output_dir PASSED               [  2%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_check_no_mode_set PASSED                     [  3%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_error_raised_for_no_manifest_with_reports_mode PASSED [  4%]
resources/home/dnanexus/dias_batch/tests/test_dias_batch.py::TestCheckInputs::test_error_raised_for_cnv_reports_invalid PASSED  [  5%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadAssayConfigFile::test_config_correctly_read PASSED [  6%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_no_config_file_found_for_assay PASSED [  7%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_no_config_files_found PASSED [  8%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_error_raised_when_path_invalid PASSED [  9%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_highest_version_correctly_selected PASSED [ 10%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetAssayConfig::test_non_live_files_skipped PASSED    [ 11%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetFileProjectContext::test_no_live_files PASSED      [ 12%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageGetFileProjectContext::test_live_files PASSED         [ 13%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_files_just_path_returned PASSED       [ 14%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_sub_dir_filters_correctly PASSED      [ 15%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFindFiles::test_archived_files_flagged_in_logs PASSED [ 16%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadDXfile::test_none_object_passed PASSED            [ 17%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadDXfile::test_file_as_dict PASSED                  [ 18%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadDXfile::test_file_as_just_file_id PASSED          [ 19%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadDXfile::test_assertion_error_raised PASSED        [ 20%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadDXfile::test_file_as_project_and_file PASSED      [ 21%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageReadDXfile::test_invalid_string_raises_error PASSED   [ 22%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageCheckArchivalState::test_all_live PASSED              [ 23%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageCheckArchivalState::test_error_raised_for_archived_files PASSED [ 24%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageCheckArchivalState::test_archived_files_filtered_out_when_not_in_sample_list PASSED [ 25%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageCheckArchivalState::test_archived_files_kept_when_in_sample_list PASSED [ 26%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageCheckArchivalState::test_error_raised_when_non_live_files_can_not_be_unarchived PASSED [ 27%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageCheckArchivalState::test_unarchive_files_called_when_specified PASSED [ 28%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageUnarchiveFiles::test_unarchiving_called PASSED        [ 29%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageUnarchiveFiles::test_error_raised_if_unable_to_unarchive PASSED [ 30%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFormatOutputFolders::test_correct_folder_app PASSED   [ 31%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXManageFormatOutputFolders::test_correct_folder_applet PASSED [ 32%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteCNVCalling::test_cnv_call PASSED                     [ 33%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteCNVCalling::test_correct_error_raised_on_calling_failing PASSED [ 33%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteCNVCalling::test_exclude PASSED                      [ 34%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteCNVCalling::test_exclude_invalid_sample PASSED       [ 35%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteCNVCalling::test_wait_on_done PASSED                 [ 36%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_cnv_mode_error_raised_when_missing_intervals_bed PASSED [ 37%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_cnv_mode_error_raised_when_missing_vcf_files PASSED [ 38%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_cnv_mode_exclude_samples_correct PASSED [ 39%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_error_raised_if_manifest_empty_after_filtering PASSED [ 40%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_error_raised_if_name_pattern_missing_from_config PASSED [ 41%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_name_suffix_integer_incremented PASSED [ 42%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_sample_limit_works PASSED      [ 43%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_samples_no_vcfs_or_mosdepth_files_added_to_errors PASSED [ 44%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_snv_mode_error_raised_when_missing_mosdepth_files PASSED [ 45%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_snv_mode_error_raised_when_missing_vcfs PASSED [ 46%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_snv_mode_filter_manifest_by_files_is_called PASSED [ 47%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteReportsWorkflow::test_xlsx_reports_found PASSED      [ 48%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteArtemis::test_called PASSED                          [ 49%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteTerminate::test_analysis_terminate PASSED            [ 50%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteTerminate::test_errors_caught PASSED                 [ 51%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py::TestDXExecuteTerminate::test_jobs_terminate PASSED                [ 52%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestTimeStamp::test_correct_format PASSED                               [ 53%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_max_suffix_snv PASSED                        [ 54%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_max_suffix_cnv PASSED                        [ 55%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_suffix_1_returned_no_previous_reports PASSED [ 56%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckReportIndex::test_prev_samples_but_no_suffix_in_name PASSED    [ 57%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestWriteSummaryReport::test_inputs_written_correctly PASSED            [ 58%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestWriteSummaryReport::test_total_no_samples_written PASSED            [ 59%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestWriteSummaryReport::test_excluded_samples_correct PASSED            [ 60%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestWriteSummaryReport::test_error_summary PASSED                       [ 61%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestWriteSummaryReport::test_report_summary PASSED                      [ 62%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestMakePath::test_path_mix PASSED                                      [ 63%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_all_reference_files_added PASSED    [ 64%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_reference_added_as_just_file_id PASSED [ 65%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_reference_added_as_dx_link_mapping PASSED [ 66%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_malformed_reference PASSED          [ 66%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFillConfigReferenceInputs::test_app_no_inputs PASSED                [ 67%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseGenePanels::test_correct_indications PASSED                    [ 68%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseGenePanels::test_correct_panels PASSED                         [ 69%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_genepanels_unchanged_by_splitting PASSED [ 70%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_splitting_r_code PASSED              [ 71%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_splitting_c_code PASSED              [ 72%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitGenePanelsTestCodes::test_catch_multiple_indication_for_one_test_code PASSED [ 73%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_gemini_not_two_columns PASSED                   [ 74%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_gemini_multiple_lines_combined PASSED           [ 75%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_gemini_invalid_codes_added_as_is PASSED         [ 76%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_correct_number_lines_parsed PASSED         [ 77%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_required_columns_checked PASSED            [ 78%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_spaces_and_sp_prefix_removed PASSED        [ 79%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_reanalysis_ids_used PASSED                 [ 80%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_epic_missing_sample_id_caught PASSED            [ 81%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_invalid_manifest PASSED                         [ 82%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_split_tests_called PASSED                       [ 83%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_subset_works PASSED                             [ 84%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestParseManifest::test_error_raised_on_invalid_sample_provided_to_subset PASSED [ 85%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_files_not_matching_pattern_filtered_out PASSED [ 86%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_samples_not_matching_pattern_filtered_out PASSED [ 87%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_sample_in_manifest_has_no_files PASSED [ 88%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestFilterManifestSamplesByFiles::test_files_correctly_added_to_manifest PASSED [ 89%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_not_raised_on_valid_codes PASSED [ 90%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_raised_when_sample_has_no_tests PASSED [ 91%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_raised_when_manifest_contains_invalid_test_code PASSED [ 92%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestCheckManifestValidTestCodes::test_error_not_raised_when_research_use_test_code_present PASSED [ 93%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitManifestTests::test_panels_correctly_split_out PASSED          [ 94%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitManifestTests::test_gene_symbols_correctly_not_split PASSED    [ 95%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestSplitManifestTests::test_panels_and_gene_symbols_handled_together_correctly PASSED [ 96%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestAddPanelsAndIndicationsToManifest::test_invalid_test_code_caught PASSED [ 97%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestAddPanelsAndIndicationsToManifest::test_correct_indications_panels PASSED [ 98%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestAddPanelsAndIndicationsToManifest::test_hgnc_ids_added PASSED       [ 99%]
resources/home/dnanexus/dias_batch/tests/test_utils.py::TestAddPanelsAndIndicationsToManifest::test_error_raised_invalid_test PASSED [100%]

========================================================= 103 passed in 8.16s =========================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/135)
<!-- Reviewable:end -->
