### PR TITLE
Array manifest input

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -22,11 +22,11 @@
             "group": ""
           },
           {
-            "name": "manifest_file",
-            "label": "manifest file",
-            "class": "file",
+            "name": "manifest_files",
+            "label": "manifest files",
+            "class": "array:file",
             "optional": true,
-            "help": "manifest file of sample -> panel",
+            "help": "manifest file(s) of sample -> panel",
             "group": ""
           },
           {

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ DNAnexus app for launching SNV, CNV and mosaic reports workflow from a given dir
 - `-iassay` (`str`): string of assay to run analysis for (CEN or TWE), used for searching of config files automatically (if `-iassay_config_file` not specified)
 - `-iassay_config_file` (`file`): Config file for assay, if not provided will search assay_config_dir for files (using `-iassay`)
 - `-isingle_output_dir` (`str`): path to output directory of Dias single to use as input files
-- `-imanifest_file` (`file`): manifest file from Epic or Gemini, maps sample ID -> required test codes / HGNC IDs (required for running any reports mode)
+- `-imanifest_files` (`array:file`): one or more manifest files from Epic or Gemini, maps sample ID -> required test codes / HGNC IDs (required for running any reports mode)
 - `-iqc_file` (`file`): xlsx file mapping QC state of each sample (_only required when `-iartemis=true` specified_)
 
 **Useful ones**
@@ -65,7 +65,7 @@ The general behaviour of each mode is as follows:
 **Minimum inputs**:
 - `-iassay` or `-iassay_config_file`
 - `-isingle_output_dir`
-- `-imanifest_file`
+- `-imanifest_files`
 - `-icnv_reports` -> `-icnv_call=true` OR `-icnv_call_job_id`
 
 **Behaviour**:
@@ -73,7 +73,7 @@ The general behaviour of each mode is as follows:
 - Search for and download latest config for assay (if not provided directly)
 - Parse through config file to add reference files to input fields
 - Download and format genepanels file
-- Download manifest
+- Download manifest(s)
     - Check provided test codes are valid and present in genepanels file
     - Get full panel and clinical indication strings for each test code from genepanels file
 - For **CNV** reports:
@@ -115,7 +115,7 @@ Running CNV calling and CNV reports for CEN assay:
 ```
 dx run app-eggd_dias_batch \
     -iassay=CEN \
-    -imanifest_file=file-xxx \
+    -imanifest_files=file-xxx \
     -isingle_output_dir=project-xxx:/path_to_output/ \
     -icnv_call=true \
     -icnv_reports=true
@@ -125,11 +125,11 @@ Running reports for CNV and SNV (using previous CNV calling output) and launchin
 ```
 dx run app-eggd_dias_batch \
     -iassay=CEN \
-    -imanifest_file=file-xxx \
+    -imanifest_files=file-xxx \
     -isingle_output_dir=project-xxx:/path_to_output/ \
     -icnv_call_job_id=job-xxx \
     -icnv_reports=true \
-    -isnv_reports=true \ 
+    -isnv_reports=true \
     -iartemis=true \
     -iqc_file=file-xxx
 ```
@@ -138,7 +138,7 @@ Running SNV reports with specified config file:
 ```
 dx run app-eggd_dias_batch \
     -iassay_config_file=file-xxx \
-    -imanifest_file=file-xxx \
+    -imanifest_files=file-xxx \
     -isingle_output_dir=project-xxx:/path_to_output/ \
     -isnv_reports=true
 ```
@@ -147,7 +147,7 @@ Running all modes in testing:
 ```
 dx run app-eggd_dias_batch \
     -iassay=CEN \
-    -imanifest_file=file-xxx \
+    -imanifest_files=file-xxx \
     -isingle_output_dir=project-xxx:/path_to_output/ \
     -icnv_call=true \
     -icnv_reports=true \
@@ -155,6 +155,19 @@ dx run app-eggd_dias_batch \
     -imosaic_reports=true
 ```
 
+Running CNV calling, CNV reports, SNV reports and Artemis with 2 manifest files:
+```
+dx run app-eggd_dias_batch \
+    -iassay=CEN \
+    -isingle_output_dir=project-xxx:/path_to_output/ \
+    -imanifest_files=file-xxx \
+    -imanifest_files=file-yyy \
+    -iqc_file=file-zzz \
+    -icnv_call=true \
+    -icnv_reports=true \
+    -isnv_reports=true \
+    -iartemis=true
+```
 
 ## Config file design
 

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -282,7 +282,7 @@ def main(
             manifest = {**manifest, **manifest_data}
             manifest_source = {**manifest_source, **source}
 
-        print("Final parsed manifest")
+        print("Parsed manifest(s)")
         prettier_print(manifest)
 
         # filter manifest tests against genepanels to ensure what has been
@@ -299,8 +299,6 @@ def main(
         )
 
         # combine manifest source for each sample into its manifest values
-        print('MANIFEST SOURCE')
-        print(manifest_source)
         manifest = {
             sample: {**manifest[sample], **manifest_source[sample]}
             for sample in manifest

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -441,13 +441,12 @@ def main(
     app_details = dxpy.DXApp(dxid=job_details['executable']).describe()
 
     # overwrite manifest job ID in job details with name to write to summary
-    manifest_names = []
-    for file in job_details['runInput']['manifest_file']:
-        manifest_names.append(dxpy.describe(
-            job_details['runInput']['manifest_file']['$dnanexus_link']
-        )['name'])
+    if manifest_files:
+        manifest_names = []
+        for file in job_details['runInput']['manifest_files']:
+            manifest_names.append(dxpy.describe(file['$dnanexus_link'])['name'])
 
-    job_details['runInput']['manifest_file'] = ', '.join(manifest_names)
+        job_details['runInput']['manifest_files'] = ', '.join(manifest_names)
 
     write_summary_report(
         summary_file,

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1233,6 +1233,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
     # minimal manifest with parsed in indications and panels
     manifest = {
         "X1234": {
+            "manifest_source": "Epic",
             "tests": [["R207.1"]],
             "panels": [
                 ["Inherited ovarian cancer (without breast cancer)_4.0"]
@@ -1242,6 +1243,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             ]]
         },
         "X5678": {
+            "manifest_source": "Epic",
             "tests": [["R134.1"]],
             "panels": [
                 ["Familial hypercholesterolaemia (GMS)_2.0"]
@@ -1309,6 +1311,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_filter_manifest.return_value = [
             {
                 "X1234": {
+                    "manifest_source": "Epic",
                     "tests": [["R207.1"]],
                     "panels": [
                         ["Inherited ovarian cancer (without breast cancer)_4.0"]
@@ -1336,6 +1339,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                     ]
                 },
                 "X5678": {
+                    "manifest_source": "Epic",
                     "tests": [["R134.1"]],
                     "panels": [
                         ["Familial hypercholesterolaemia (GMS)_2.0"]
@@ -1396,15 +1400,14 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         expects to have Epic or Gemini as keys to use
         """
         with pytest.raises(
-            AssertionError,
-            match=f'No name pattern found for Gemini parsed from assay config file'
+            RuntimeError,
+            match='Unable to correctly parse manifest source. Parsed: set()'
         ):
             DXExecute().reports_workflow(
                 mode='CNV',
                 workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
                 single_output_dir='/path_to_single/',
                 manifest={},
-                manifest_source='Gemini',
                 config={},
                 start='230925_0943',
                 name_patterns={},
@@ -1419,7 +1422,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
 
         n.b. here we're setting the mode to something invalid to stop the
         function going further and letting it raise a RuntimeError after
-        the xlsx reports have been parsed, so we don't have to patch lots 
+        the xlsx reports have been parsed, so we don't have to patch lots
         more for this test (mainly for laziness)
         """
         # minimal set of xlsx reports found
@@ -1446,8 +1449,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                 mode='test',
                 workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
                 single_output_dir='/path_to_single/',
-                manifest={},
-                manifest_source='Epic',
+                manifest={'sample1': {'manifest_source': 'Epic'}},
                 config=self.assay_config,
                 start='230925_0943',
                 name_patterns={'Epic': '[\d\w]+-[\d\w]+'},
@@ -1476,7 +1478,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                 workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
                 single_output_dir='/path_to_single/',
                 manifest=self.manifest,
-                manifest_source='Gemini',
                 config=self.assay_config['modes']['cnv_reports'],
                 start='230925_0943',
                 name_patterns=self.assay_config['name_patterns'],
@@ -1507,7 +1508,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                 workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
                 single_output_dir='/path_to_single/',
                 manifest=self.manifest,
-                manifest_source='Gemini',
                 config=self.assay_config['modes']['cnv_reports'],
                 start='230925_0943',
                 name_patterns={'Gemini': 'X[\d]+'},
@@ -1551,7 +1551,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
             single_output_dir='/path_to_single/',
             manifest=self.manifest,
-            manifest_source='Gemini',
             config=self.assay_config['modes']['cnv_reports'],
             start='230925_0943',
             name_patterns=self.assay_config['name_patterns'],
@@ -1586,7 +1585,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                 workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
                 single_output_dir='/path_to_single/',
                 manifest=self.manifest,
-                manifest_source='Gemini',
                 config=self.assay_config['modes']['snv_reports'],
                 start='230925_0943',
                 name_patterns=self.assay_config['name_patterns']
@@ -1621,7 +1619,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
                 workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
                 single_output_dir='/path_to_single/',
                 manifest=self.manifest,
-                manifest_source='Gemini',
                 config=self.assay_config['modes']['snv_reports'],
                 start='230925_0943',
                 name_patterns=self.assay_config['name_patterns']
@@ -1665,7 +1662,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
             single_output_dir='/path_to_single/',
             manifest=self.manifest,
-            manifest_source='Gemini',
             config=self.assay_config['modes']['snv_reports'],
             start='230925_0943',
             name_patterns=self.assay_config['name_patterns']
@@ -1722,7 +1718,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
             single_output_dir='/path_to_single/',
             manifest=self.manifest,
-            manifest_source='Gemini',
             config=self.assay_config['modes']['snv_reports'],
             start='230925_0943',
             name_patterns=self.assay_config['name_patterns']
@@ -1730,8 +1725,8 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
 
         expected_errors = {
             (
-                'Samples in manifest not matching expected Gemini pattern '
-                '(1) ^X[\\d]+'
+                'Samples in manifest not matching expected Epic pattern '
+                '(1) ^[\\d\\w]+-[\\d\\w]+'
             ): ['X1928'],
             'Samples in manifest with no mosdepth files found (1)': ['X1928'],
             'Samples in manifest with no VCF found (1)': ['X1928']
@@ -1783,7 +1778,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
             single_output_dir='/path_to_single/',
             manifest=self.manifest,
-            manifest_source='Gemini',
             config=self.assay_config['modes']['snv_reports'],
             start='230925_0943',
             name_patterns=self.assay_config['name_patterns']
@@ -1839,8 +1833,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             mode='SNV',
             workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
             single_output_dir='/path_to_single/',
-            manifest=filled_manifest,
-            manifest_source='Gemini',
+            manifest=filled_manifest[0],
             config=self.assay_config['modes']['snv_reports'],
             start='230925_0943',
             name_patterns=self.assay_config['name_patterns']
@@ -1885,7 +1878,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
             workflow_id='workflow-GXzvJq84XZB1fJk9fBfG88XJ',
             single_output_dir='/path_to_single/',
             manifest=self.manifest,
-            manifest_source='Gemini',
             config=self.assay_config['modes']['snv_reports'],
             start='230925_0943',
             name_patterns=self.assay_config['name_patterns'],

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -118,7 +118,6 @@ class TestCheckReportIndex():
         )
 
 
-
 class TestWriteSummaryReport():
     """
     Tests for utils.write_summary_report()
@@ -146,7 +145,7 @@ class TestWriteSummaryReport():
             'assay_config_file': {
                 '$dnanexus_link': 'file-GZFV3184VjyV3JZgQx0GBkBz'
             },
-            'manifest_file': 'manifest.txt',
+            'manifest_files': 'manifest.txt',
             'qc_file': {
                 '$dnanexus_link': 'file-GYPg1fj4YXKbxV560Zfy3XFv'
             }
@@ -245,8 +244,11 @@ class TestWriteSummaryReport():
             x.replace('\t', '') for x in written_inputs if x
         ])
 
+        original_inputs = deepcopy(self.job_details['runInput'])
+        original_inputs['Manifest(s) parsed'] = 'manifest.txt'
+
         original_inputs = sorted([
-            f"{k}: {v}" for k, v in self.job_details['runInput'].items()
+            f"{k}: {v}" for k, v in original_inputs.items()
         ])
 
         assert written_inputs == original_inputs, 'Inputs incorrectly written'

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -721,7 +721,6 @@ class DXExecute():
             workflow_id,
             single_output_dir,
             manifest,
-            manifest_source,
             config,
             start,
             name_patterns,
@@ -746,9 +745,6 @@ class DXExecute():
             dnanexus path to Dias single output
         manifest : dict
             mapping of sampleID -> testCodes parsed from manifest
-        manifest_source : str
-            source of manifest (Epic or Gemini), required for filtering
-            pattern against sample name
         config : dict
             subset of assay config file containing the inputs for the given
             mode being run (i.e. {'modes': {'cnv_reports': {...}})
@@ -779,7 +775,7 @@ class DXExecute():
             dict of any errors found (i.e samples with no files)
         dict
             dict of per sample summary of names used for jobs
-        
+
         Raises
         ------
         AssertionError
@@ -817,15 +813,23 @@ class DXExecute():
             reports = '\n\t'.join(sorted(xlsx_reports))
             print(f"xlsx reports found:\n\t{reports}")
 
+        # this will either be Epic, Gemini or both
+        manifest_source = set([x['manifest_source'] for x in manifest.values()])
+
         if manifest_source == 'Epic':
             pattern = name_patterns.get('Epic')
-        else:
+        elif manifest_source == 'Gemini':
             pattern = name_patterns.get('Gemini')
-
-        assert pattern, (
-            f"No name pattern found for {manifest_source} parsed from "
-            "assay config file"
-        )
+        elif manifest_source == {'Epic', 'Gemini'}:
+            # got 2 (or more) manifests with a mix => use both
+            pattern = (
+                fr"{name_patterns.get('Epic')}|{name_patterns.get('Gemini')}"
+            )
+        else:
+            # who knows what happens if we got here
+            raise RuntimeError(
+                f'Unable to correctly parse manifest source. Parsed: {manifest_source}'
+            )
 
         vcf_files = []
         mosdepth_files = []

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -80,7 +80,7 @@ class DXManage():
         -------
         dict
             contents of config file
-        
+
         Raises
         ------
         AssertionError
@@ -287,7 +287,7 @@ class DXManage():
         -------
         list
             contents of file as a list split on '\n'
-        
+
         Raises
         ------
         RuntimeError
@@ -343,7 +343,7 @@ class DXManage():
             can be unarchived
         - archived -> file fully archived, will take time to unarchive fully
         - unarchiving -> already requested unarchiving but not yet
-            completed, skip trying to unarchive again 
+            completed, skip trying to unarchive again
 
         Parameters
         ---------
@@ -353,7 +353,7 @@ class DXManage():
             if to automatically unarchive files
         samples : list
             list of sample names to filter down files to check
-        
+
         Raises
         ------
         RuntimeError
@@ -611,7 +611,7 @@ class DXExecute():
         -------
         str
             job ID of launch cnv calling job
-        
+
         Raises
         ------
         dxpy.exceptions.DXJobFailureError
@@ -813,18 +813,23 @@ class DXExecute():
             reports = '\n\t'.join(sorted(xlsx_reports))
             print(f"xlsx reports found:\n\t{reports}")
 
+        print(manifest)
+
         # this will either be Epic, Gemini or both
         manifest_source = set([x['manifest_source'] for x in manifest.values()])
 
         if manifest_source == {'Epic'}:
             pattern = name_patterns.get('Epic')
+            manifest_source = 'Epic'
         elif manifest_source == {'Gemini'}:
             pattern = name_patterns.get('Gemini')
+            manifest_source = 'Gemini'
         elif manifest_source == {'Epic', 'Gemini'}:
             # got 2 (or more) manifests with a mix => use both
             pattern = (
                 fr"{name_patterns.get('Epic')}|{name_patterns.get('Gemini')}"
             )
+            manifest_source = 'Epic&Gemini'
         else:
             # who knows what happens if we got here
             raise RuntimeError(
@@ -930,7 +935,7 @@ class DXExecute():
             if not vcf_files:
                 error = (
                     f"Found no vcf files! {mode} reports in {single_output_dir} "
-                    f"and subdir {vcf_dir} with pattern {vcf_name}" 
+                    f"and subdir {vcf_dir} with pattern {vcf_name}"
                 )
 
                 raise RuntimeError(error)

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -816,9 +816,9 @@ class DXExecute():
         # this will either be Epic, Gemini or both
         manifest_source = set([x['manifest_source'] for x in manifest.values()])
 
-        if manifest_source == 'Epic':
+        if manifest_source == {'Epic'}:
             pattern = name_patterns.get('Epic')
-        elif manifest_source == 'Gemini':
+        elif manifest_source == {'Gemini'}:
             pattern = name_patterns.get('Gemini')
         elif manifest_source == {'Epic', 'Gemini'}:
             # got 2 (or more) manifests with a mix => use both

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -827,7 +827,7 @@ class DXExecute():
         elif manifest_source == {'Epic', 'Gemini'}:
             # got 2 (or more) manifests with a mix => use both
             pattern = (
-                fr"{name_patterns.get('Epic')}|{name_patterns.get('Gemini')}"
+                fr"{name_patterns.get('Gemini')}|{name_patterns.get('Epic')}"
             )
             manifest_source = 'Epic&Gemini'
         else:

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -778,7 +778,7 @@ class DXExecute():
 
         Raises
         ------
-        AssertionError
+        RuntimeError
             Raised when name patterns not present in config file
         RuntimeError
             Raised when invalid mode set
@@ -813,7 +813,6 @@ class DXExecute():
             reports = '\n\t'.join(sorted(xlsx_reports))
             print(f"xlsx reports found:\n\t{reports}")
 
-        print(manifest)
 
         # this will either be Epic, Gemini or both
         manifest_source = set([x['manifest_source'] for x in manifest.values()])

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -217,7 +217,7 @@ def fill_config_reference_inputs(config) -> dict:
     -------
     dict
         config with input files parsed in
-    
+
     Raises
     ------
     RuntimeError
@@ -300,7 +300,7 @@ def parse_genepanels(contents) -> pd.DataFrame:
     This will drop the HGNC ID column and keep the unique rows left (i.e.
     one row per clinical indication / panel), and adds the test code as
     a separate column.
-    
+
     Example resultant dataframe:
 
     +-----------+-----------------------+---------------------------+

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -346,7 +346,7 @@ def split_genepanels_test_codes(genepanels) -> pd.DataFrame:
 
                                     |
                                     ▼
-                                        
+
     +-----------+-----------------------+---------------------------+
     | test_code |      indication      |        panel_name          |
     +-----------+-----------------------+---------------------------+
@@ -364,7 +364,7 @@ def split_genepanels_test_codes(genepanels) -> pd.DataFrame:
     -------
     pd.DataFrame
         genepanels with test code split to separate column
-    
+
     Raises
     ------
     RuntimeError
@@ -522,7 +522,6 @@ def parse_manifest(contents, split_tests=False, subset=None) -> Tuple[pd.DataFra
             '-' + manifest['Re-analysis Specimen ID']
 
         manifest = manifest[['SampleID', 'ReanalysisID', 'Test Codes']]
-        manifest_source = 'Epic'
 
         data = defaultdict(lambda: defaultdict(list))
 

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -638,6 +638,7 @@ def filter_manifest_samples_by_files(
         "Total files after filtering against pattern: "
         f"{len(file_prefixes.keys())}"
     )
+    print(file_prefixes)
 
     manifest_no_match = []
     manifest_no_files = []

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -638,7 +638,6 @@ def filter_manifest_samples_by_files(
         "Total files after filtering against pattern: "
         f"{len(file_prefixes.keys())}"
     )
-    print(file_prefixes)
 
     manifest_no_match = []
     manifest_no_files = []

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -122,6 +122,9 @@ def write_summary_report(output, job, app, manifest=None, **summary) -> None:
 
         if manifest:
             file_handle.write(
+                f"\nManifest(s) parsed: {job['runInput']['manifest_files']}\n"
+            )
+            file_handle.write(
                 f"\nTotal number of samples in manifest: {len(manifest.keys())}\n"
             )
 


### PR DESCRIPTION
## Summary

Handle array of manifest files to be able to process runs in one go where samples are split between Gemini and Epic manifest files

## Changes
- `-manifest_file` input changed to `-imanifest_files`
- manifest source (Epic or Gemini) now stored in manifest dict after parsing each manifest to pass to reports workflow calling
- fixed unit tests for new behaviour

Examples jobs:
- Epic + Gemini manifest: https://platform.dnanexus.com/projects/GZ025k04VjykZx3bKJ7YP837/monitor/job/Gb4P7284Vjyzjx13Kv0FpKpf
- single Epic manifest: https://platform.dnanexus.com/projects/GZ025k04VjykZx3bKJ7YP837/monitor/job/Gb4PV204VjygxP8bkGjZk648
- single Gemini manifest: https://platform.dnanexus.com/projects/GZ025k04VjykZx3bKJ7YP837/monitor/job/Gb4PV4Q4Vjyg7k91534G5q34

Unit tests passing:
```
Jethros-MBP:dias_batch_running jethro$ python3 -m pytest resources/home/dnanexus/dias_batch/
============================================================== test session starts ==============================================================
platform darwin -- Python 3.9.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch
configfile: pytest.ini
plugins: mock-3.12.0
collected 103 items                                                                                                                             

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py ......                                                                        [  5%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py ................................................                             [ 52%]
resources/home/dnanexus/dias_batch/tests/test_utils.py .................................................                                  [100%]

=============================================================== warnings summary ================================================================
resources/home/dnanexus/dias_batch/utils/utils.py:508: 3 warnings
tests/test_utils.py: 7 warnings
  /Users/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch/utils/utils.py:508: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
    manifest[columns] = manifest[columns].applymap(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 103 passed, 10 warnings in 3.02s ========================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/137)
<!-- Reviewable:end -->
