### PR TITLE
More robustly handle parsing of both Epic and Gemini manifests

### DIFF
--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -815,15 +815,16 @@ class DXExecute():
 
 
         # this will either be Epic, Gemini or both
-        manifest_source = set([x['manifest_source'] for x in manifest.values()])
+        manifest_source = sorted(set([
+            x['manifest_source'] for x in manifest.values()]))
 
-        if manifest_source == {'Epic'}:
+        if manifest_source == ['Epic']:
             pattern = name_patterns.get('Epic')
             manifest_source = 'Epic'
-        elif manifest_source == {'Gemini'}:
+        elif manifest_source == ['Gemini']:
             pattern = name_patterns.get('Gemini')
             manifest_source = 'Gemini'
-        elif manifest_source == {'Epic', 'Gemini'}:
+        elif manifest_source == ['Epic', 'Gemini']:
             # got 2 (or more) manifests with a mix => use both
             pattern = (
                 fr"{name_patterns.get('Gemini')}|{name_patterns.get('Epic')}"


### PR DESCRIPTION
use `sorted()` to ensure when both Epic and Gemini manifests specified that they will always be in the expected order

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/139)
<!-- Reviewable:end -->
