### PR TITLE
Fix to improve single gene parsing

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1232,10 +1232,8 @@ class TestAddPanelsAndIndicationsToManifest():
                 "tests": [["R208.1"]],
                 "panels": [
                     [
-                        "HGNC:1100_SG_panel_1.0.0;HGNC:1101_SG_panel_1.0.0;"
-                        "HGNC:16627_SG_panel_1.0.0;HGNC:26144_SG_panel_1.0.0;"
-                        "HGNC:795_SG_panel_1.0.0;HGNC:9820_SG_panel_1.0.0;"
-                        "HGNC:9823_SG_panel_1.0.0"
+                        "HGNC:1100;HGNC:1101;HGNC:16627;HGNC:26144;HGNC:795;"
+                        "HGNC:9820;HGNC:9823_SG_panel_1.0.0"
                     ]
                 ],
                 "indications": [
@@ -1255,11 +1253,9 @@ class TestAddPanelsAndIndicationsToManifest():
                 "tests": [["R208.1", "R216.1"]],
                 "panels": [
                     [
-                        "HGNC:1100_SG_panel_1.0.0;HGNC:1101_SG_panel_1.0.0;"
-                        "HGNC:16627_SG_panel_1.0.0;HGNC:26144_SG_panel_1.0.0;"
-                        "HGNC:795_SG_panel_1.0.0;HGNC:9820_SG_panel_1.0.0;"
-                        "HGNC:9823_SG_panel_1.0.0",
-                        "HGNC:11998_SG_panel_1.0.0;HGNC:17284_SG_panel_1.0.0"
+                        "HGNC:1100;HGNC:1101;HGNC:16627;HGNC:26144;HGNC:795;"
+                        "HGNC:9820;HGNC:9823_SG_panel_1.0.0",
+                        "HGNC:11998;HGNC:17284_SG_panel_1.0.0"
                     ]
                 ],
                 "indications": [

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -909,6 +909,14 @@ def add_panels_and_indications_to_manifest(manifest, genepanels) -> dict:
                         panel_str = ';'.join(
                             genepanels_row['panel_name'].tolist()
                         )
+
+                        # try clean up the panel string and drop
+                        # duplicated _SG_panel_1.0.0
+                        if '_SG_panel_1.0.0' in panel_str:
+                            panel_str = (
+                                f"{re.sub(r'_SG_panel_1.0.0', '', panel_str)}"
+                                "_SG_panel_1.0.0"
+                            )
                     else:
                         # this is nice and sane and 1:1
                         panel_str = genepanels_row.iloc[0].panel_name


### PR DESCRIPTION
Tests passing:
```
jethro@jethro-T490:~/Projects/dias_batch_running$ python3 -m pytest resources/home/dnanexus/dias_batch/tests/
======================================================================================= test session starts =======================================================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch, configfile: pytest.ini
plugins: Faker-14.0.0, subtests-0.11.0, html-4.1.0, metadata-3.0.0, mock-3.11.1, cov-4.0.0
collected 103 items                                                                                                                                                                               

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py ......                                                                                                                          [  5%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py ................................................                                                                               [ 52%]
resources/home/dnanexus/dias_batch/tests/test_utils.py .................................................                                                                                    [100%]

======================================================================================= 103 passed in 2.73s =======================================================================================
```

Fiixes #138

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/142)
<!-- Reviewable:end -->
