### PR TITLE
V3.0.0 testing fixes - check cnv call mode set

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 
 **Strings**
 - `-iassay_config_dir` (`str`): DNANexus project:path to directory containing config files, the highest version for the given `-iassay` string will be used
-- `-icnv_call_job_id` (`str`): job ID of cnv calling job to use for generating CNV reports if CNV calling is not first being run
+- `-icnv_call_job_id` (`str`): job ID of cnv calling job to use for generating CNV reports if CNV calling is not first being run (_n.b. this is mutually exclusive with `-icnv_call`_)
 - `-iexclude_samples` (`str`): comma separated string of samples to exclude from CNV calling / CNV reports (these should be formatted as ` InstrumentID-SpecimenID` (i.e. `123245111-33202R00111`))
 - `-imanifest_subset` (`str`): comma separated string of samples in manifest on which to ONLY run jobs (these should be formatted as ` InstrumentID-SpecimenID` (i.e. `123245111-33202R00111`))
 
@@ -32,7 +32,7 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 
 
 #### Running modes
-- `-icnv_call` (`bool`): controls if to run CNV calling
+- `-icnv_call` (`bool`): controls if to run CNV calling (_n.b. this is mutually exclusive with `-icnv_call_job_id`_)
 - `-icnv_reports` (`bool`): controls if to run CNV reports workflows
 - `-isnv_reports` (`bool`): controls if to run SNV reports workflows
 - `-imosaic_reports` (`bool`): controls if to run mosaic reports workflow

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -65,8 +65,10 @@ class CheckInputs():
         self.check_assay_config_dir()
         self.check_mode_set()
         self.check_single_output_dir()
+        self.check_cnv_call_and_cnv_call_job_id_mutually_exclusive()
         self.check_cnv_calling_for_cnv_reports()
         self.check_artemis_inputs()
+        self.check_exclude_str_and_file()
 
         if self.errors:
             errors = '; '.join(x for x in self.errors)
@@ -157,7 +159,7 @@ class CheckInputs():
                 'Reports argument specified with no manifest file'
             )
 
-    def check_cnv_calling_cnv_job_id_mutually_exclusive(self):
+    def check_cnv_call_and_cnv_call_job_id_mutually_exclusive(self):
         """
         Check that both cnv_call and cnv_call_job_id have not been
         specified together

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -167,7 +167,7 @@ class CheckInputs():
         if self.inputs.get('cnv_call') and self.inputs.get('cnv_call_job_id'):
             self.errors.append(
                 'Both mutually exclusive cnv_call and '
-                'cnv_call_job_id inputs  specified'
+                'cnv_call_job_id inputs specified'
             )
 
     def check_cnv_calling_for_cnv_reports(self):

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -69,9 +69,9 @@ class CheckInputs():
         self.check_artemis_inputs()
 
         if self.errors:
-            errors = '\n\t'.join(x for x in self.errors)
+            errors = '; '.join(x for x in self.errors)
             raise RuntimeError(
-                f"Errors in inputs passed:\n\t{errors}"
+                f"Errors in job inputs:\n\t{errors}"
             )
 
         print("Inputs valid, continuing...")
@@ -155,6 +155,17 @@ class CheckInputs():
         ]) and not self.inputs.get('manifest_files'):
             self.errors.append(
                 'Reports argument specified with no manifest file'
+            )
+
+    def check_cnv_calling_cnv_job_id_mutually_exclusive(self):
+        """
+        Check that both cnv_call and cnv_call_job_id have not been
+        specified together
+        """
+        if self.inputs.get('cnv_call') and self.inputs.get('cnv_call_job_id'):
+            self.errors.append(
+                'Both mutually exclusive cnv_call and '
+                'cnv_call_job_id inputs  specified'
             )
 
     def check_cnv_calling_for_cnv_reports(self):

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -134,6 +134,31 @@ class TestCheckInputs():
             'Error not raised for reports mode and missing manifest'
         )
 
+    def test_error_raised_invalid_cnv_mode(self, mocker):
+        """
+        Test error is raised when both cnv_call and cnv_call_job_id specified
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+        check.inputs = {}
+
+        check.inputs['cnv_call'] = True
+        check.inputs['cnv_call_job_id'] = 'job-xxx'
+
+        check.check_cnv_call_and_cnv_call_job_id_mutually_exclusive()
+
+        correct_error = ([
+            "Both mutually exclusive cnv_call and "
+            "cnv_call_job_id inputs specified"
+        ])
+
+        assert check.errors == correct_error, (
+            'Incorrect error raised for checking cnv call mode'
+        )
+
+
     def test_error_raised_for_cnv_reports_invalid(self, mocker):
         """
         Test when CNV reports is to be run that an error is raised if


### PR DESCRIPTION
- Add additional check to ensure both `-icnv_call` and `-icnv_call_job_id` specified together
- Test job: https://platform.dnanexus.com/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbX997Q4ZxYQJj4V8kXyfbJQ
- Tests passing:
```
Jethros-MBP:dias_batch_running jethro$ python3 -m pytest --disable-warnings resources/home/dnanexus/dias_batch/tests/
================================================================= test session starts =================================================================
platform darwin -- Python 3.9.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch
configfile: pytest.ini
plugins: mock-3.12.0
collected 104 items                                                                                                                                   

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py .......                                                                             [  6%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py ................................................                                   [ 52%]
resources/home/dnanexus/dias_batch/tests/test_utils.py .................................................                                        [100%]

========================================================== 104 passed, 10 warnings in 6.91s ===========================================================
```