### PR TITLE
v3.0.0 testing fixes - improve checking of exclude_samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.py
 /*.txt
 /*.tsv
 *.coverage
+htmlcov/*

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -112,11 +112,11 @@ class CheckInputs():
         if not self.inputs.get('single_output_dir'):
             return
 
-        if self.inputs['single_output_dir'].startswith('project'):
-            project, path = self.inputs['single_output_dir'].split(':')
+        if self.inputs['single_output_dir'].startswith('project-'):
+            project, path = self.inputs['single_output_dir'].strip().split(':')
         else:
             project = os.environ.get("DX_PROJECT_CONTEXT_ID")
-            path = self.inputs['single_output_dir']
+            path = self.inputs['single_output_dir'].strip()
 
         files = list(dxpy.find_data_objects(
             project=project,

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -69,6 +69,7 @@ class CheckInputs():
         self.check_cnv_calling_for_cnv_reports()
         self.check_artemis_inputs()
         self.check_exclude_str_and_file()
+        self.check_exclude_samples_file_id()
 
         if self.errors:
             errors = '; '.join(x for x in self.errors)
@@ -212,6 +213,19 @@ class CheckInputs():
                 "Both -iexclude_samples and -iexclude_samples_file specified, "
                 "only one may be specified"
             )
+
+    def check_exclude_samples_file_id(self):
+        """
+        Check if input to -iexclude_samples is a file-xxx string and should
+        have been provided to -iexclude_samples_file
+        """
+        if self.inputs.get('exclude_samples'):
+            if re.match(r"file-", self.inputs.get('exclude_samples')):
+                self.errors.append(
+                    "DNAnexus file ID provided to -iexclude_samples, "
+                    "rerun and provide this as -iexclude_samples_file="
+                    f"{self.inputs.get('exclude_samples')}"
+                )
 
 
 @dxpy.entry_point('main')

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -183,6 +183,32 @@ class TestCheckInputs():
         )
 
 
+    def test_exclude_samples_with_file_id(self, mocker):
+        """
+        Test for check_exclude_samples_file_id() to check if a file ID
+        has been provided to exclude_samples instead of exclude_samples_file
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+
+        check.inputs = {
+            "exclude_samples": "file-abc123"
+        }
+
+        check.check_exclude_samples_file_id()
+
+        correct_error = ([
+            "DNAnexus file ID provided to -iexclude_samples, "
+            "rerun and provide this as -iexclude_samples_file=file-abc123"
+        ])
+
+        assert check.errors == correct_error, (
+            "Error not raise from file ID provided to exclude_samples"
+        )
+
+
 class TestMain():
     """
     Tests for dias_batch.main

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1131,29 +1131,24 @@ class TestDXExecuteCNVCalling(unittest.TestCase):
 
     def test_exclude_invalid_sample(self):
         """
-        Test when exclude samples is specified with a sample not in BAM
-        files that a warning is printed
+        Test when exclude samples is specified with an sample name that
+        has no BAM file present a RuntimeError is correctly raised from
+        the call to utils.check_exclude_samples
         """
-        DXExecute().cnv_calling(
-            config=deepcopy(self.config),
-            single_output_dir='',
-            exclude=['sample1000'],
-            start='',
-            wait=False,
-            unarchive=False
+        correct_error = (
+            "samples provided to exclude from CNV calling not valid: "
+            r"\['sample1000'\]"
         )
 
-        stdout = self.capsys.readouterr().out
-
-        correct_warning = (
-            "WARNING: sample ID(s) provided to exclude not present in bam "
-            "files found for CNV calling:\n\t['sample1000']\nIgnoring "
-            "these and continuing..."
-        )
-
-        assert correct_warning in stdout, (
-            'Invalid exclude sample specified not correctly removed'
-        )
+        with pytest.raises(RuntimeError, match=correct_error):
+            DXExecute().cnv_calling(
+                config=deepcopy(self.config),
+                single_output_dir='',
+                exclude=['sample1000'],
+                start='',
+                wait=False,
+                unarchive=False
+            )
 
 
     def test_correct_error_raised_on_calling_failing(self):

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1333,3 +1333,53 @@ class TestCheckExcludeSamples():
     list of BAM files (for CNV calling) or the manifest (CNV reports) to
     ensure all samples specified are valid for excluding
     """
+    def test_error_raised_when_no_bam_files(self):
+        """
+        Test when sample specified to exclude has no BAM files
+        found, check will be when running for CNV calling
+        """
+        samples = [
+            'sample1.bam',
+            'sample2.bam',
+            'sample3.bam'
+        ]
+
+        exclude = ['sample4']
+
+        expected_error = (
+            "samples provided to exclude from CNV calling not "
+            r"valid: \['sample4'\]"
+        )
+
+        with pytest.raises(RuntimeError, match=expected_error):
+            utils.check_exclude_samples(
+                samples=samples,
+                exclude=exclude,
+                mode='calling'
+            )
+
+    def test_error_raised_when_sample_not_in_manifest(self):
+        """
+        Test error raised when sample specified to exclude not in
+        the samples parsed from the manifest, check will be running
+        when CNV calling
+        """
+        samples = [
+            'sample1-a',
+            'sample2-b',
+            'sample-c'
+        ]
+
+        exclude = ['sample-d']
+
+        expected_error = (
+            "samples provided to exclude from CNV reports not "
+            r"valid: \['sample-d'\]"
+        )
+
+        with pytest.raises(RuntimeError, match=expected_error):
+            utils.check_exclude_samples(
+                samples=samples,
+                exclude=exclude,
+                mode='reports'
+            )

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1323,3 +1323,13 @@ class TestAddPanelsAndIndicationsToManifest():
                 manifest=manifest,
                 genepanels=self.genepanels
             )
+
+
+class TestCheckExcludeSamples():
+    """
+    Tests for utils.check_exclude_samples()
+
+    Function checks the specified list of exclude samples against either
+    list of BAM files (for CNV calling) or the manifest (CNV reports) to
+    ensure all samples specified are valid for excluding
+    """

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -632,9 +632,14 @@ class DXExecute():
             single_output_dir, cnv_config['inputs']['bambais']['folder']
         )
 
+        # check if we're searching for files in different project
+        remote_project = re.match(r"project-[\w]+", single_output_dir)
+        if remote_project:
+            bam_dir = f"{remote_project.group()}:{bam_dir}"
+
         files = DXManage().find_files(
             pattern=cnv_config['inputs']['bambais']['name'],
-            path=f"{os.environ.get('DX_PROJECT_CONTEXT_ID')}:{bam_dir}"
+            path=bam_dir
         )
 
         printable_files = '\n\t'.join([x['describe']['name'] for x in files])

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -944,3 +944,53 @@ def add_panels_and_indications_to_manifest(manifest, genepanels) -> dict:
     PPRINT(manifest_with_panels)
 
     return manifest_with_panels
+
+
+def check_exclude_samples(samples, exclude, mode) -> dict:
+    """
+    Exclude samples specified to either -iexclude_samples or
+    -iexclude_samples_file from the manifest used for CNV calling
+    and / or CNV reports
+
+    Parameters
+    ----------
+    samples : list
+        list of sample names, will either be list of bam files found
+        (before CNV calling) or sample names from manifest (if called
+        from CNV reports)
+    exclude : list[str]
+        list of sample names to exclude from generating reports (n.b.
+        this is ONLY for CNV reports), will be formatted as
+        InstrumentID-SpecimenID (i.e. [123245111-33202R00111, ...])
+    mode : str
+        calling | reports, used to add context to error message
+
+    Raises
+    -------
+    RuntimeError
+        Raised when one or more exclude_samples not present in sample list
+    """
+    exclude_not_present = [
+        name for name in exclude
+        if not any([sample.startswith(name) for sample in samples])
+    ]
+
+    if exclude_not_present:
+        # provide some more info in logs for debugging
+        print(
+            f"Samples provided to exclude: {exclude}"
+        )
+        if mode == "calling":
+            print(f"BAM files found to use for CNV calling: {samples}")
+        else:
+            print(f"Samples parsed from manifest: {samples}")
+
+        print(
+            "Samples specified to exclude that do not appear to be valid: "
+            f"{exclude_not_present}"
+        )
+
+        raise RuntimeError(
+            f"samples provided to exclude from CNV {mode} "
+            f"not valid: {exclude_not_present}"
+        )


### PR DESCRIPTION
- Add function `utils.check_exclude_samples()` to check for sample names provided to `-exclude_samples` that they are valid before CNV calling and CNV reports
- Add tests for new function
- Add check for file ID being provided to `exclude_samples` instead of `exclude_samples_file`
- Add additional check for the above
- Add `strip()` to `single_output_dir` input to ensure no annoying whitespace errors
- Example job with `-icnv_call` and invalid exclude sample: https://platform.dnanexus.com/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbXJX604ZxYZygZz8QpxKv98
- Example job with `-icnv_reports` and invalid exclude sample: https://platform.dnanexus.com/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbXJZy04ZxYyqvB36vJ5124x
- Tests passing:
```
Jethros-MBP:dias_batch_running jethro$ python3 -m pytest --disable-warnings  resources/home/dnanexus/dias_batch/ 
================================================================= test session starts =================================================================
platform darwin -- Python 3.9.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/jethro/Projects/dias_batch_running/resources/home/dnanexus/dias_batch
configfile: pytest.ini
plugins: html-4.1.1, cov-4.1.0, metadata-3.0.0, mock-3.12.0
collected 107 items                                                                                                                                   

resources/home/dnanexus/dias_batch/tests/test_dias_batch.py ........                                                                            [  7%]
resources/home/dnanexus/dias_batch/tests/test_dx_requests.py ................................................                                   [ 52%]
resources/home/dnanexus/dias_batch/tests/test_utils.py ...................................................                                      [100%]

========================================================== 107 passed, 10 warnings in 6.70s ===========================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/148)
<!-- Reviewable:end -->
