### PR TITLE
v3.0.0 - athena version check

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1269,6 +1269,8 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.workflow_patch = mock.patch('utils.dx_requests.dxpy.DXWorkflow')
         self.describe_patch = mock.patch('utils.dx_requests.dxpy.describe')
         self.timer_patch = mock.patch('utils.dx_requests.timer')
+        self.athena_patch = mock.patch('utils.dx_requests.check_athena_version')
+
 
         self.mock_find = self.find_patch.start()
         self.mock_job = self.job_patch.start()
@@ -1280,6 +1282,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_workflow = self.workflow_patch.start()
         self.mock_describe = self.describe_patch.start()
         self.mock_timer = self.timer_patch.start()
+        self.mock_athena = self.athena_patch.start()
 
 
         # Below are some generalised expected returns for each of the
@@ -1376,7 +1379,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_workflow.stop()
         self.mock_describe.stop()
         self.mock_timer.stop()
-
+        self.mock_athena.stop()
 
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1325,6 +1325,67 @@ class TestAddPanelsAndIndicationsToManifest():
             )
 
 
+class TestCheckAthenaVersion():
+    """
+    Tests for utils.check_athena_version()
+
+    Function checks from the workflow details if eggd_athena/1.6.0+ is
+    being used as this has an additional input, this allows for backwards
+    compatibility with dias_reports using eggd_athena <1.6.0
+
+    We will test that when the eggd_athena app of version 1.4.0 (current
+    in dias reports) is present the input is not added, and when 1.6.0+
+    it is added
+    """
+    def test_version_1_4_0(self):
+        """
+        Test when egdd_athena/1.4.0 is in workflow that the input is
+        not added to the input dict
+        """
+        workflow_details = {
+            "stages": [
+                {
+                    "executable": "eggd_athena/1.4.0"
+                }
+            ]
+        }
+
+        input = utils.check_athena_version(
+            workflow=workflow_details,
+            stage_inputs={},
+            indications='test_indication'
+        )
+
+        assert input == {}, "workflow inputs wrongly modified for athena 1.4.0"
+
+    def test_version_6_4_0(self):
+        """
+        Test when egdd_athena/1.6.0 is in workflow that the indication
+        input is added to the input dict
+        """
+        workflow_details = {
+            "stages": [
+                {
+                    "executable": "eggd_athena/1.6.0"
+                }
+            ]
+        }
+
+        expected_return = {
+            'stage-rpt_athena.indication': 'test_indication'
+        }
+
+        input = utils.check_athena_version(
+            workflow=workflow_details,
+            stage_inputs={},
+            indications='test_indication'
+        )
+
+        assert input == expected_return, (
+            "workflow inputs wrongly modified for athena 1.6.0"
+        )
+
+
 class TestCheckExcludeSamples():
     """
     Tests for utils.check_exclude_samples()

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -17,6 +17,7 @@ from packaging.version import Version
 import pandas as pd
 
 from .utils import (
+    check_athena_version,
     check_exclude_samples,
     check_report_index,
     filter_manifest_samples_by_files,
@@ -1144,6 +1145,13 @@ class DXExecute():
                     input['stage-rpt_generate_workbook.output_prefix'] = name
                     input['stage-rpt_athena.name'] = name
 
+                    # handle new input in eggd_athena v1.6.0 and still using
+                    # eggd_athena v1.4.0, can be removed once > v1.4.0 used
+                    input = check_athena_version(
+                        workflow=workflow_details,
+                        stage_inputs=input,
+                        indications=indications
+                    )
 
                 # now we can finally run the reports workflow
                 job_handle = dxpy.DXWorkflow(

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -11,6 +11,7 @@ from time import strftime, localtime
 from typing import Tuple
 
 import dxpy
+from packaging.version import Version
 import pandas as pd
 
 # for prettier viewing in the logs
@@ -944,6 +945,38 @@ def add_panels_and_indications_to_manifest(manifest, genepanels) -> dict:
     PPRINT(manifest_with_panels)
 
     return manifest_with_panels
+
+
+def check_athena_version(workflow, stage_inputs, indications) -> dict:
+    """
+    Checks the version of eggd_athena being used in SNV reports workflow,
+    and if >=1.6.0 adds additional input of clinical indication string.
+
+    Parameters
+    ----------
+    workflow : dict
+        dxpy.describe() output of the workflow
+    stage_inputs : dict
+        inputs dictionary to add input to
+    indications : str
+        str of clinical indication to add as input to eggd_athena/1.6.0+
+
+    Returns
+    -------
+    dict
+        inputs dictionary with added input
+    """
+    athena_version = [
+        x['executable'] for x in workflow['stages']
+        if 'athena' in x['executable']
+    ][0]
+
+    if Version(
+        re.search(r'[\d]\.[\d]\.[\d]', athena_version).group()
+    ) >= '1.6.0':
+        stage_inputs['stage-rpt_athena.indication'] = indications
+
+    return stage_inputs
 
 
 def check_exclude_samples(samples, exclude, mode) -> dict:

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -969,12 +969,13 @@ def check_athena_version(workflow, stage_inputs, indications) -> dict:
     athena_version = [
         x['executable'] for x in workflow['stages']
         if 'athena' in x['executable']
-    ][0]
+    ]
 
-    if Version(
-        re.search(r'[\d]\.[\d]\.[\d]', athena_version).group()
-    ) >= '1.6.0':
-        stage_inputs['stage-rpt_athena.indication'] = indications
+    if athena_version:
+        if Version(
+            re.search(r'[\d]\.[\d]\.[\d]', athena_version[0]).group()
+        ) >= Version('1.6.0'):
+            stage_inputs['stage-rpt_athena.indication'] = indications
 
     return stage_inputs
 


### PR DESCRIPTION
- add check for athena version in reports workflow, for >=v1.6.0 will add new `indication` input
- added unit tests for new `utils.check_athena_version()`
- fix unit tests for `dx_requests.DXExecute.reports_workflow` with added function call patched

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/150)
<!-- Reviewable:end -->
