### PR TITLE
v3.0.0 - add project name as input for CNV calling

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1037,9 +1037,13 @@ class TestDXExecuteCNVCalling(unittest.TestCase):
             }
         ]
 
-        # first dxpy.describe call is on app ID, second is on job ID
+        # first dxpy.describe call is on the project ID to get the project
+        # name, second is on app ID and third is on job ID
         # patch in minimal responses with required keys
         self.mock_describe.side_effect = [
+            {
+                'name': '002_test_project'
+            },
             {
                 'name': 'GATK_gCNV_call',
                 'version': '1.2.3'

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -633,10 +633,17 @@ class DXExecute():
             single_output_dir, cnv_config['inputs']['bambais']['folder']
         )
 
-        # check if we're searching for files in different project
+        # check if we're searching for files in different project,
+        # and set the project input name accordingly
         remote_project = re.match(r"project-[\w]+", single_output_dir)
         if remote_project:
             bam_dir = f"{remote_project.group()}:{bam_dir}"
+            project_name = dxpy.describe(remote_project.group()).get('name')
+        else:
+            project_name = dxpy.describe(
+                os.environ.get('DX_PROJECT_CONTEXT_ID')).get('name')
+
+        cnv_config['inputs']['run_name'] = project_name
 
         files = DXManage().find_files(
             pattern=cnv_config['inputs']['bambais']['name'],


### PR DESCRIPTION
Adds project name of where provided BAM files are located as input for CNV calling


Test job: https://platform.dnanexus.com/panx/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbgQ0FQ4ZxYgqk7V1GxF4K8G

Launched CNV call job: 
![image](https://github.com/eastgenomics/dias_batch_running/assets/45037268/de68e60f-12d6-497d-8671-8d6f4e8633ae)
