### PR TITLE
v3.0.0 - fix DXManage.get_file_project_context

### DIFF
--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -180,10 +180,10 @@ class DXManage():
         print(f"Searching all projects for: {file}")
 
         # find projects where file exists and get DXFile objects for
-        # each to check archivalState, list_projects() returns list of
-        # dicts where key is the project ID and value is permission level
+        # each to check archivalState, list_projects() returns dict
+        # where key is the project ID and value is permission level
         projects = dxpy.DXFile(dxid=file).list_projects()
-        print(f"Found file in {len(projects)} projects")
+        print(f"Found file in {len(projects)} project(s)")
 
         files = [
             dxpy.DXFile(dxid=file, project=id).describe()

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -179,17 +179,22 @@ class DXManage():
         """
         print(f"Searching all projects for: {file}")
 
-        file_details = dxpy.DXFile(dxid=file).describe()
-        files = dxpy.find_data_objects(
-            name=file_details['name'],
-            describe=True
-        )
+        # find projects where file exists and get DXFile objects for
+        # each to check archivalState, list_projects() returns list of
+        # dicts where key is the project ID and value is permission level
+        projects = dxpy.DXFile(dxid=file).list_projects()
+        print(f"Found file in {len(projects)} projects")
+
+        files = [
+            dxpy.DXFile(dxid=file, project=id).describe()
+            for id in projects.keys()
+        ]
 
         # filter out any archived files or those resolving
         # to the current job container context
         files = [
             x for x in files
-            if x['describe']['archivalState'] == 'live'
+            if x['archivalState'] == 'live'
             and not re.match(r"^container-[\d\w]+$", x['project'])
         ]
         assert files, f"No live files could be found for the ID: {file}"


### PR DESCRIPTION
Fix for correctly finding project context of a given file by using `dxpy.DXFile.list_projects` over `dxpy.find_data_objects()`, previously would incorrectly find files with duplicate name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/153)
<!-- Reviewable:end -->
