### PR TITLE
v3.0.0 - make the logs great again

### DIFF
--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -37,12 +37,19 @@ def prettier_print(thing) -> None:
     Pretty print for nicer viewing in the logs since pprint does not
     do an amazing job visualising big dicts and long strings
 
+    Bonus: we're indenting using the Braille Pattern Blank U+2800
+    unicode character since the new DNAnexus UI (as of Dec. 2023)
+    strips leading tabs and spaces in the logs, which makes viewing
+    the pretty dicts terrible. Luckily they don't strip other
+    whitespace characters, so we can get around them yet again making
+    their UI worse.
+
     Parameters
     ----------
     thing : anything json dumpable
         thing to print
     """
-    print(json.dumps(thing, indent=4))
+    print(json.dumps(thing, indent='⠀⠀'))
 
 
 def check_report_index(name, reports) -> int:


### PR DESCRIPTION
New DNAnexus UI makes the logs worse and strips all leading tabs/whitespace, which results in any dicts in the logs being a single level and being unreadable, this fixes this by indenting using non-standard whitespace character which isn't removed and reverts back to how it looked in the previous logs with the prettier printing

Before:
![image](https://github.com/eastgenomics/dias_batch_running/assets/45037268/2d94e915-15cb-4874-b37f-27743154dd29)

After: 
![image](https://github.com/eastgenomics/dias_batch_running/assets/45037268/6f8e6078-bccb-4a48-a259-275b9b9c48a0)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/155)
<!-- Reviewable:end -->
