### PR TITLE
v3.0.0 - fix bam searching

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -483,7 +483,7 @@ class TestDXManageFindFiles():
         expected_warning = (
             'WARNING: some files found are in an archived state, if these are '
             'for samples to be analysed this will raise an error...'
-            '\n[\n    "file1 (file-xxx)"\n]'
+            '\n[\n⠀⠀"file1 (file-xxx)"\n]'
         )
 
         assert expected_warning in stdout, (

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -620,15 +620,14 @@ class DXExecute():
         cnv_config = config['modes']['cnv_call']
 
         # find BAM files and format as $dnanexus_link inputs to add to config
-        bam_dir = make_path(
-            single_output_dir, cnv_config['inputs']['bambais']['folder']
-        )
+        # bam_dir = make_path(
+        #     single_output_dir, cnv_config['inputs']['bambais']['folder']
+        # )
 
         # check if we're searching for files in different project,
         # and set the project input name accordingly
         remote_project = re.match(r"project-[\w]+", single_output_dir)
         if remote_project:
-            bam_dir = f"{remote_project.group()}:{bam_dir}"
             project_name = dxpy.describe(remote_project.group()).get('name')
         else:
             project_name = dxpy.describe(
@@ -638,7 +637,8 @@ class DXExecute():
 
         files = DXManage().find_files(
             pattern=cnv_config['inputs']['bambais']['name'],
-            path=bam_dir
+            path=single_output_dir,
+            subdir=cnv_config['inputs']['bambais']['folder']
         )
 
         # sense check we find files and the dir isn't empty
@@ -646,7 +646,7 @@ class DXExecute():
 
         printable_files = '\n\t'.join([x['describe']['name'] for x in files])
         print(
-            f"Found {len(files)} .bam/.bai files in {bam_dir}:"
+            f"Found {len(files)} .bam/.bai files:"
             f"\n\t{printable_files}"
         )
 

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -619,11 +619,6 @@ class DXExecute():
         print("\n \nBuilding inputs for CNV calling")
         cnv_config = config['modes']['cnv_call']
 
-        # find BAM files and format as $dnanexus_link inputs to add to config
-        # bam_dir = make_path(
-        #     single_output_dir, cnv_config['inputs']['bambais']['folder']
-        # )
-
         # check if we're searching for files in different project,
         # and set the project input name accordingly
         remote_project = re.match(r"project-[\w]+", single_output_dir)


### PR DESCRIPTION
Change when searching for BAM files for CNV calling to specify sub dir instead of including in initial search path to handle incomplete path names

Test job: https://platform.dnanexus.com/panx/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbgYx6Q4ZxYb69Qvy3z1QXv0

From logs: 
![image](https://github.com/eastgenomics/dias_batch_running/assets/45037268/db20dd4d-a487-4673-b16b-32d51fecddf3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/157)
<!-- Reviewable:end -->
