### PR TITLE
v3.0.0 - fix bam searching

### DIFF
--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -895,7 +895,8 @@ class DXExecute():
                 check_exclude_samples(
                     samples=manifest.keys(),
                     exclude=exclude,
-                    mode='reports'
+                    mode='reports',
+                    single_dir=single_output_dir
                 )
 
                 excluded = [


### PR DESCRIPTION
- add additional check when checking validity of sample names provided to `-exclude_samples` before running CNV reports, for those that are not present in the manifest (i.e have been not included due to failing QC) we check if they have a BAM file present, and if they do use this as being a valid sample name. This is required as the same list of sample names is used to also exclude from the manifest, which is not a required input for CNV calling.
- 2 additional unit tests have been added to cover the additional logic for checking for BAM files and keep 100% coverage on utils.py
- test job: https://platform.dnanexus.com/panx/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbjG16Q4ZxYVBZ6Yyfk3FZVZ