### PR TITLE
Check QC file is an .xlsx report

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -43,7 +43,7 @@
             "label": "QC file",
             "class": "file",
             "optional": true,
-            "help": "QC .xlsx file, required if running eggd_artemis"
+            "help": "QC .xlsx file. optional input to eggd_artemis"
           },
           {
             "name": "split_tests",
@@ -64,7 +64,7 @@
             "label": "exclude samples file",
             "class": "file",
             "optional": true,
-            "help": "file of samples to exclude from CNV calling / CNV reports, one sample name per line (as found in manifest)"
+            "help": "file of samples to exclude from CNV calling / CNV reports, one sample name per line (`InstrumentID-SpecimenID` for Epic samples, X number for Gemini samples)"
           },
           {
             "name": "manifest_subset",

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 - `-iassay` (`str`): string of assay to run analysis for (CEN or TWE), used for searching of config files automatically (if `-iassay_config_file` not specified)
 - `-isingle_output_dir` (`str`): path to output directory of Dias single to use as input files
 - `-imanifest_files` (`array:file`): one or more manifest files from Epic or Gemini, maps sample ID -> required test codes / HGNC IDs (required for running any reports mode)
+- one or more running modes, see [running modes](#running-modes)
 
 
 #### Useful ones
@@ -54,7 +55,7 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 
 ## How does this app work?
 
-The app takes as a minimum input a path to Dias single output and an assay config. The assay config file may be passed directly (with `-iassay_config_file`) or an assay string specified to run for (with `-iassay`) which will search DNAnexus for the highest version config file and use this for analysis. If running a reports workflow a manifest file must also be specified.
+The app takes as a minimum input a path to Dias single output, an assay config, and at least one of the above listed running modes. The default behaviour is to pass an assay string specified to run for (with `-iassay`), which will search DNAnexus for the highest version config file in `-iassay_config_dir`  (default: `default_path`)  and use this for analysis. Alternatively, an assay config file may be specified to use instead with `-iassay_config_file`. If running a reports workflow a manifest file must also be specified.
 
 The general behaviour of each mode is as follows:
 

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 
 ## How does this app work?
 
-The app takes as a minimum input a path to Dias single output, an assay config, and at least one of the above listed running modes. The default behaviour is to pass an assay string specified to run for (with `-iassay`), which will search DNAnexus for the highest version config file in `-iassay_config_dir`  (default: `default_path`)  and use this for analysis. Alternatively, an assay config file may be specified to use instead with `-iassay_config_file`. If running a reports workflow a manifest file must also be specified.
+The app takes as a minimum input a path to Dias single output, an assay config, and at least one of the above listed running modes. The default behaviour is to pass an assay string specified to run for (with `-iassay`), which will search DNAnexus for the highest version config file in `-iassay_config_dir`  (default: `001_Reference:/dynamic_files/dias_batch_configs/`)  and use this for analysis. Alternatively, an assay config file may be specified to use instead with `-iassay_config_file`. If running a reports workflow a manifest file must also be specified.
 
 The general behaviour of each mode is as follows:
 

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -72,7 +72,6 @@ class CheckInputs():
         self.check_exclude_samples_file_id()
         self.check_qc_file()
 
-
         if self.errors:
             errors = '; '.join(x for x in self.errors)
             raise RuntimeError(

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -203,20 +203,19 @@ class CheckInputs():
 
     def check_qc_file(self):
         """Check QC status file for artemis is an .xlsx as expected"""
-        if self.inputs.get('artemis'):
-            if self.inputs.get('qc_file'):
-                file=self.inputs.get('qc_file').get('$dnanexus_link')
-                file_details = dxpy.DXFile(
-                    re.match(r'file-[\d\w]+', file).group()
-                ).describe()
-                qc_file_name = file_details['name']
+        if self.inputs.get('artemis') and self.inputs.get('qc_file'):
+            file = self.inputs.get('qc_file').get('$dnanexus_link')
+            file_details = dxpy.DXFile(
+                re.match(r'file-[\d\w]+', file).group()
+            ).describe()
+            qc_file_name = file_details['name']
 
-                if not qc_file_name.endswith(".xlsx"):
-                    self.errors.append(
-                        "Artemis specified to run with QC status file. File "
-                        "given as QC status report is not an .xlsx file. "
-                        "Please rerun with correct QC status file"
-                    )
+            if not qc_file_name.endswith(".xlsx"):
+                self.errors.append(
+                    "Artemis specified to run with QC status file. File "
+                    "given as QC status report is not an .xlsx file. "
+                    "Please rerun with correct QC status file"
+                )
 
     def check_exclude_str_and_file(self):
         """

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -205,7 +205,7 @@ class CheckInputs():
         """Check QC status file for artemis is an .xlsx as expected"""
         if self.inputs.get('artemis'):
             if self.inputs.get('qc_file'):
-                if not re.match(r".xlsx$", str(self.inputs.get('qc_file'))):
+                if not re.search(r".xlsx$", str(self.inputs.get('qc_file'))):
                     self.errors.append(
                     "Artemis specified to run with QC status file. File given "
                     "as QC status report is not an .xlsx file. Please rerun "

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -205,7 +205,14 @@ class CheckInputs():
         """Check QC status file for artemis is an .xlsx as expected"""
         if self.inputs.get('artemis'):
             if self.inputs.get('qc_file'):
-                if not re.search(r".xlsx$", str(self.inputs.get('qc_file'))):
+                file_details = dxpy.DXFile(
+                    re.match(
+                        r'file-[\d\w]+', self.inputs.get('qc_file')
+                    ).group()
+                ).describe()
+                qc_file_name = file_details['name']
+
+                if not re.search(r".xlsx$", qc_file_name):
                     self.errors.append(
                     "Artemis specified to run with QC status file. File given "
                     "as QC status report is not an .xlsx file. Please rerun "

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -211,7 +211,7 @@ class CheckInputs():
                 ).describe()
                 qc_file_name = file_details['name']
 
-                if not re.search(r".xlsx$", qc_file_name):
+                if not qc_file_name.endswith(".xlsx"):
                     self.errors.append(
                         "Artemis specified to run with QC status file. File "
                         "given as QC status report is not an .xlsx file. "

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -205,19 +205,18 @@ class CheckInputs():
         """Check QC status file for artemis is an .xlsx as expected"""
         if self.inputs.get('artemis'):
             if self.inputs.get('qc_file'):
+                file=self.inputs.get('qc_file').get('$dnanexus_link')
                 file_details = dxpy.DXFile(
-                    re.match(
-                        r'file-[\d\w]+', self.inputs.get('qc_file')
-                    ).group()
+                    re.match(r'file-[\d\w]+', file).group()
                 ).describe()
                 qc_file_name = file_details['name']
 
                 if not re.search(r".xlsx$", qc_file_name):
                     self.errors.append(
-                    "Artemis specified to run with QC status file. File given "
-                    "as QC status report is not an .xlsx file. Please rerun "
-                    "with correct QC status file"
-                )
+                        "Artemis specified to run with QC status file. File "
+                        "given as QC status report is not an .xlsx file. "
+                        "Please rerun with correct QC status file"
+                    )
 
     def check_exclude_str_and_file(self):
         """

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -70,6 +70,8 @@ class CheckInputs():
         self.check_artemis_inputs()
         self.check_exclude_str_and_file()
         self.check_exclude_samples_file_id()
+        self.check_qc_file()
+
 
         if self.errors:
             errors = '; '.join(x for x in self.errors)
@@ -198,6 +200,17 @@ class CheckInputs():
                     "Artemis specified to run but no snv or cnv reports "
                     "specified. Please rerun with -icnv_reports and / or "
                     "-isnv_reports"
+                )
+
+    def check_qc_file(self):
+        """Check QC status file for artemis is an .xlsx as expected"""
+        if self.inputs.get('artemis'):
+            if self.inputs.get('qc_file'):
+                if not re.match(r".xlsx$", str(self.inputs.get('qc_file'))):
+                    self.errors.append(
+                    "Artemis specified to run with QC status file. File given "
+                    "as QC status report is not an .xlsx file. Please rerun "
+                    "with correct QC status file"
                 )
 
     def check_exclude_str_and_file(self):

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -209,7 +209,6 @@ class TestCheckInputs():
             "Error not raised when file ID provided to exclude_samples"
         )
 
-    #@patch('utils.dx_requests.dxpy.DXFile.describe')
     @patch('utils.dx_requests.dxpy.DXFile')
     def test_qc_status_file_is_valid(self, mock_file, mocker):
         """

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -3,7 +3,6 @@ Tests for CheckInputs() that are run at the beginning of dias batch
 """
 import os
 import sys
-import dxpy
 from unittest.mock import patch
 
 

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -205,7 +205,34 @@ class TestCheckInputs():
         ])
 
         assert check.errors == correct_error, (
-            "Error not raise from file ID provided to exclude_samples"
+            "Error not raised when file ID provided to exclude_samples"
+        )
+
+    def test_qc_status_file_is_valid(self, mocker):
+        """
+        Test check_qc_file() to check that an error will be raised if a
+        file that is not an .xlsx file is passed as the QC status file,
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        mocker.return_value = None
+        check = CheckInputs()
+        check.errors = []
+
+        check.inputs = {
+            'artemis': True,
+            'qc_file': "file.fastq"
+        }
+
+        check.check_qc_file()
+
+        correct_error = ([
+            "Artemis specified to run with QC status file. File given "
+            "as QC status report is not an .xlsx file. Please rerun "
+            "with correct QC status file"
+        ])
+
+        assert check.errors == correct_error, (
+            "Error not raised when non .xlsx file provided to check_qc_file()"
         )
 
 

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -3,6 +3,7 @@ Tests for CheckInputs() that are run at the beginning of dias batch
 """
 import os
 import sys
+import dxpy
 from unittest.mock import patch
 
 
@@ -208,7 +209,9 @@ class TestCheckInputs():
             "Error not raised when file ID provided to exclude_samples"
         )
 
-    def test_qc_status_file_is_valid(self, mocker):
+    #@patch('utils.dx_requests.dxpy.DXFile.describe')
+    @patch('utils.dx_requests.dxpy.DXFile')
+    def test_qc_status_file_is_valid(self, mock_file, mocker):
         """
         Test check_qc_file() to check that an error will be raised if a
         file that is not an .xlsx file is passed as the QC status file,
@@ -217,10 +220,16 @@ class TestCheckInputs():
         mocker.return_value = None
         check = CheckInputs()
         check.errors = []
-
         check.inputs = {
             'artemis': True,
-            'qc_file': "file.fastq"
+            'qc_file': {
+                 '$dnanexus_link': "file-xxx"
+            }
+        }
+
+        mock_file.return_value.describe.return_value = {
+            'file': "file-xxx",
+            'name': "file.fastq"
         }
 
         check.check_qc_file()

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -226,7 +226,6 @@ class TestCheckInputs():
         }
 
         mock_file.return_value.describe.return_value = {
-            'file': "file-xxx",
             'name': "file.fastq"
         }
 


### PR DESCRIPTION
Test job to see that correct error is raised
https://platform.dnanexus.com/panx/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbqVBqQ4ZxYXf1p6jpPKKgxZ
This used a fastq as the QC status input and has the correct error message:

![image](https://github.com/eastgenomics/dias_batch_running/assets/71272357/f314ff0f-3e33-4c19-b08f-ad2874a703e3)


Job : https://platform.dnanexus.com/panx/projects/GbQ9gJ04ZxYYZ5JPk3GVVjGp/monitor/job/GbqVGG84ZxYy5JJfjfGY20GK
Launches all required jobs:

![image](https://github.com/eastgenomics/dias_batch_running/assets/71272357/7bc285dd-7240-4090-853d-950390f0ab27)
This fails due to it being an applet, not an app, but the .xlsx testing does work

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/160)
<!-- Reviewable:end -->
