### PR TITLE
Di 641 v3.0.1

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
     "name": "eggd_dias_batch",
     "title": "eggd_dias_batch",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "summary": "Launches downstream analyses for Dias",
     "dxapi": "1.0.0",
     "inputSpec": [

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -457,7 +457,8 @@ def main(
                 qc_xlsx=qc_file,
                 snv_output=snv_path,
                 cnv_output=cnv_path,
-                capture_bed=assay_config['modes']['artemis']['inputs']['capture_bed']
+                capture_bed=assay_config['modes']['artemis']['inputs']['capture_bed'],
+                url_duration=assay_config['modes']['artemis']['inputs']['url_duration']
             )
 
             launched_jobs['artemis'] = [artemis_job]

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -359,27 +359,20 @@ def main(
         parent = None
 
     if cnv_call:
-        if cnv_call_job_id:
-            print(
-                "WARNING: both 'cnv_call' set and 'cnv_call_job_id' "
-                "specified.\nWill use output of specified job "
-                f"({cnv_call_job_id}) instead of running CNV calling."
-            )
-        else:
-            # check if we're running reports after and to hold app
-            # until CNV calling completes
-            wait = True if cnv_reports else False
+        # check if we're running reports after and to hold app
+        # until CNV calling completes
+        wait = True if cnv_reports else False
 
-            cnv_call_job_id = DXExecute().cnv_calling(
-                config=assay_config,
-                single_output_dir=single_output_dir,
-                exclude=exclude_samples,
-                start=start_time,
-                wait=wait,
-                unarchive=unarchive
-            )
+        cnv_call_job_id = DXExecute().cnv_calling(
+            config=assay_config,
+            single_output_dir=single_output_dir,
+            exclude=exclude_samples,
+            start=start_time,
+            wait=wait,
+            unarchive=unarchive
+        )
 
-            launched_jobs['CNV calling'] = [cnv_call_job_id]
+        launched_jobs['CNV calling'] = [cnv_call_job_id]
 
     if cnv_reports:
         cnv_report_jobs, cnv_report_errors, cnv_report_summary = \

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1982,7 +1982,8 @@ class TestDXExecuteArtemis():
             qc_xlsx='file-xxx',
             capture_bed='file-xxx',
             snv_output=None,
-            cnv_output=None
+            cnv_output=None,
+            url_duration=None
         )
 
         assert job == 'job-QaTZ9qEwkEsovKLs14DSdNqb', (

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1195,7 +1195,8 @@ class DXExecute():
             qc_xlsx,
             capture_bed,
             snv_output=None,
-            cnv_output=None
+            cnv_output=None,
+            url_duration=None
         ) -> str:
         """
         Launch eggd_artemis to generate xlsx file of download links
@@ -1218,6 +1219,8 @@ class DXExecute():
             output path of SNV reports (if run), by default None
         cnv_output : str (optional)
             output path of CNV reports (if run), by default None
+        url_duration : str (optional)
+            expiry time in seconds for artemis urls, by default None
 
         Returns
         -------
@@ -1227,12 +1230,21 @@ class DXExecute():
         details = dxpy.DXApp(app_id).describe()
         path = make_path(single_output_dir, details['name'], start)
 
-        app_input = {
-            "snv_path": snv_output,
-            "cnv_path": cnv_output,
-            "qc_status": qc_xlsx,
-            "bed_file": capture_bed
-        }
+        if url_duration:
+            app_input = {
+                "snv_path": snv_output,
+                "cnv_path": cnv_output,
+                "qc_status": qc_xlsx,
+                "bed_file": capture_bed,
+                "url_duration": url_duration
+            }
+        else:
+            app_input = {
+                "snv_path": snv_output,
+                "cnv_path": cnv_output,
+                "qc_status": qc_xlsx,
+                "bed_file": capture_bed,
+            }
 
         job = dxpy.DXApp(dxid=app_id).run(
             app_input=app_input,


### PR DESCRIPTION
Update eggd_dias_batch to be able to parse url_duration from the config and pass on to eggd_artemis. This means url_duration can be set from the config. eggd_dias_batch was built as an applet to test (applet-Gf6k3PQ46k5F095GgvQ2GYYy)

Example eggd_dias_batch job with url duration set from config: https://platform.dnanexus.com/panx/projects/Gf6fPz046k5582p9PvFYf8ZZ/monitor/job/Gf7F8X046k50YGyyqK3YyK43

Example artemis job launched by above batch job showing that url duration is now set as 15811200 from the config, rather than 4838400 which is the default: https://platform.dnanexus.com/panx/projects/Gf6fPz046k5582p9PvFYf8ZZ/monitor/job/Gf7F9pj46k5PzPX3ZF4G8VGY
![image](https://github.com/eastgenomics/dias_batch_running/assets/71272357/125f7db9-b9ed-41b8-8b96-22a30cfc5df6)
Resulting .xlsx expires 29/6/2024 which is in six months:
![image](https://github.com/eastgenomics/dias_batch_running/assets/71272357/5f4bcb56-cd7a-4fb4-acec-0fd293269ccc)

Delete unused warning from dias_batch script to address #165

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dias_batch_running/166)
<!-- Reviewable:end -->
